### PR TITLE
Add curry and pipe functions

### DIFF
--- a/lua/plenary/functional.lua
+++ b/lua/plenary/functional.lua
@@ -53,4 +53,26 @@ function f.last(...)
   return x
 end
 
+function f.curry(f)
+  return function(x)
+    return f(x)
+  end
+end
+
+function f.curry2(f)
+  return function(x)
+    return function(y)
+      return f(x, y)
+    end
+  end
+end
+
+function f.pipe(x, ...)
+  if ... ~= nil then
+    return f.pipe(f.first(...)(x), select(2, ...))
+  else
+    return x
+  end
+end
+
 return f


### PR DESCRIPTION
Example usage:

```lua
-- Just to make examples cleaner
local function dump(x) print(vim.inspect(x)) end

-- curry/curry2
dump(vim.tbl_map(f.curry(tostring), {1, 2, 3, 4})) -- '{ "1", "2", "3", "4"}'

local function add(x, y) return x + y end
dump(vim.tbl_map(f.curry2(add)(5), {1, 2, 3, 4})) -- '{ 6, 7, 8, 9 }'

-- pipe
f.pipe(
  {1, 2, 3, 4, 5},
  f.curry2(vim.tbl_filter)(function(x) return x % 2 == 0 end),
  f.curry2(vim.tbl_map)(function(x) return tostring(x * 10) end),
  vim.inspect,
  print
) -- '{ "20", "40"}'
```

Here's a quick-and-dirty benchmark for two versions of the `pipe` function (the recursive one being the one I've pushed for now) vs. normal code. On my machine, `pipe_iterative` appears to be slightly faster than `pipe_recursive`, and both of the pipe functions are about a second slower than the normal code example. I do think the pipe version is more readable and easier to write though, so it's being slightly slower is mostly made up for by the readability in many cases I'd think.
```lua
local function pipe_recursive(x, ...)
  if ... ~= nil then
    return pipe_recursive(f.first(...)(x), select(2, ...))
  else
    return x
  end
end

local function pipe_iterative(x, ...)
  local ret = x
  for _, f in ipairs({...}) do
    ret = f(ret)
  end

  return ret
end

local bench = require'plenary.profile'.benchmark
local function piped_iter()
  pipe_iterative(
    {1, 2, 3, 4, 5},
    f.curry2(vim.tbl_filter)(function(x) return x % 2 == 0 end),
    f.curry2(vim.tbl_map)(function(x) return tostring(x * 10) end),
    vim.inspect
  )
end

local function piped_recursive()
  pipe_recursive(
    {1, 2, 3, 4, 5},
    f.curry2(vim.tbl_filter)(function(x) return x % 2 == 0 end),
    f.curry2(vim.tbl_map)(function(x) return tostring(x * 10) end),
    vim.inspect
  )
end

local function normal()
  vim.inspect(
    vim.tbl_map(
      function(x) return tostring(x * 10) end,
      vim.tbl_filter(
        function(x) return x % 2 == 0 end,
        {1, 2, 3, 4, 5})))
end

print('Iter', bench(1E6, piped_iter))
print('Recursive', bench(1E6, piped_recursive))
print('Normal', bench(1E6, normal))

```

Let me know which of the `pipe` implementations you want me to use in this PR (the iterative or recursive one or another one if you have something better/faster). It's quite possible I'm missing some optimizations, so I wouldn't be that surprised if these could be made faster.