### PR TITLE
fix: Prevents off by 1 for results list.

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -172,11 +172,11 @@ local on_output = function(self, cb)
         results[result_index] = line
       end
 
-      if found_newline then
-        if cb then
-          cb(err, results[result_index], self)
-        end
+      if cb then
+        cb(err, results[result_index], self)
+      end
 
+      if found_newline then
         -- Stop processing if we've surpassed the maximum.
         if self._maximum_results then
           if result_index > self._maximum_results then


### PR DESCRIPTION
If we get a list, the last result may/may not have a new line. `fd`
does not end with a new line. That prevents it from processing the
last result.

This fixes that by always running the callback. Tested with
telescope and seems to be working.