### PR TITLE
Only create stdin handle if job is a writer

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -88,6 +88,7 @@ function Job:new(o)
     obj.interactive = true
   else
     obj.interactive = o.interactive
+  end
 
   -- enable_handlers: Do you want to do ANYTHING with the stdout/stderr of the proc
   obj.enable_handlers = F.if_nil(o.enable_handlers, true, o.enable_handlers)
@@ -323,7 +324,7 @@ function Job:_prepare_pipes()
   end
 
   if not self.stdin then
-    self.stdin = (self.interactive == true) and uv.new_pipe(false) or nil
+    self.stdin = self.interactive and uv.new_pipe(false) or nil
   end
 
   self.stdout = uv.new_pipe(false)

--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -319,7 +319,7 @@ function Job:_prepare_pipes()
   end
 
   if not self.stdin then
-    self.stdin = uv.new_pipe(false)
+    self.stdin = nil
   end
 
   self.stdout = uv.new_pipe(false)

--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -84,6 +84,10 @@ function Job:new(o)
   obj.args = o.args
   obj.cwd = o.cwd and vim.fn.expand(o.cwd)
   obj.env = o.env
+  if o.interactive == nil then
+    obj.interactive = true
+  else
+    obj.interactive = o.interactive
 
   -- enable_handlers: Do you want to do ANYTHING with the stdout/stderr of the proc
   obj.enable_handlers = F.if_nil(o.enable_handlers, true, o.enable_handlers)
@@ -319,7 +323,7 @@ function Job:_prepare_pipes()
   end
 
   if not self.stdin then
-    self.stdin = nil
+    self.stdin = (self.interactive == true) and uv.new_pipe(false) or nil
   end
 
   self.stdout = uv.new_pipe(false)


### PR DESCRIPTION
This seems to fix the issue with [Telescopes](https://github.com/nvim-lua/telescope.nvim) `live_grep` on Windows 10, for some reason if we pass a `stdin` handle but never write to it, the process hangs and never returns. This might only happen in some scenarios since output was already working for other jobs for example `find_files`, I tested both using `rg` as a backend.

I don't see why a job that isn't writing anything would need a `stdin` handle open, so this seems like a safe change?