### PR TITLE
In lua find using `vim.loop.fs_`

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -358,4 +358,14 @@ function Path:readlines()
   return vim.split(data, "\n")
 end
 
+function Path:iter()
+  local data = self:readlines()
+  local i = 0
+  local n = table.getn(data)
+  return function()
+    i = i + 1
+    if i <= n then return data[i] end
+  end
+end
+
 return Path

--- a/lua/plenary/scandir.lua
+++ b/lua/plenary/scandir.lua
@@ -1,0 +1,309 @@
+local Path = require'plenary.path'
+local os_sep = Path.path.sep
+
+local uv = vim.loop
+
+local m = {}
+
+local get_gitignore = function(path)
+  local gitignore = {}
+  local p = Path:new(path .. os_sep .. '.gitignore')
+  if not p:exists() then return nil end
+  for v in p:iter() do
+    if v ~= '' then
+      local w = v:gsub('%#.*', '')
+      w = w:gsub('%.', '%%.')
+      w = w:gsub('%*', '%.%*')
+      if w ~= '' then
+        table.insert(gitignore, w)
+      end
+    end
+  end
+  return gitignore
+end
+
+local interpret_gitignore = function(gitignore, entry)
+  for _, v in ipairs(gitignore) do
+    if entry:match(v) then return false end
+  end
+  return true
+end
+
+local handle_depth = function(base_paths, entry, depth)
+  for _, v in ipairs(base_paths) do
+    if entry:find(v, 1, true) then
+      local cut = entry:sub(#v + 1, -1)
+      cut = cut:sub(1, 1) == os_sep and cut:sub(2, -1) or cut
+      local _, count = cut:gsub(os_sep, "")
+      if depth <= (count + 1) then
+        return nil
+      end
+    end
+  end
+  return entry
+end
+
+local gen_search_pat = function(pattern)
+  if type(pattern) == 'string' then
+    return function(entry)
+      return entry:match(pattern)
+    end
+  elseif type(pattern) == 'table' then
+    return function(entry)
+      for _, v in ipairs(pattern) do
+        if entry:match(v) then return true end
+      end
+      return false
+    end
+  end
+end
+
+local process_item = function(opts, name, typ, current_dir, next_dir, bp, data, giti, msp, cb)
+  if opts.hidden or name:sub(1, 1) ~= '.' then
+    if typ == 'directory' then
+      local entry = current_dir .. '/' .. name
+      if opts.depth then
+        table.insert(next_dir, handle_depth(bp, entry, opts.depth))
+      else
+        table.insert(next_dir, entry)
+      end
+      if opts.add_dirs then
+        if not msp or msp(entry) then
+          table.insert(data, entry)
+          if cb then cb(entry) end
+        end
+      end
+    else
+      local entry = current_dir .. '/' .. name
+      if not giti or interpret_gitignore(giti, entry) then
+        if not msp or msp(entry) then
+          table.insert(data, entry)
+          if cb then cb(entry) end
+        end
+      end
+    end
+  end
+end
+
+--- m.scan_dir
+-- Search directory recursive and syncronous
+-- @param path: string or table
+--   string has to be a valid path
+--   table has to be a array of valid paths
+-- @param opts: table to change behavior
+--   opts.hidden (bool):              if true hidden files will be added
+--   opts.add_dirs (bool):            if true dirs will also be added to the results
+--   opts.respect_gitignore (bool):   if true will only add files that are not ignored by the gitignore. Uses gitignore of the first path when a table is passed in(for now). Doesn't fail if gitignore is not found
+--   opts.depth (int):                depth on how deep the search should go
+--   opts.search_pattern (regex):     regex for which files will be added, string or table of strings
+-- @param callback: on_stdout callback: Will be called for each element
+-- @return array with files
+m.scan_dir = function(path, opts, callback)
+  opts = opts or {}
+
+  local data = {}
+  local base_paths = vim.tbl_flatten { path }
+  local next_dir = vim.tbl_flatten { path }
+
+  local gitignore = opts.respect_gitignore and get_gitignore(base_paths[1]) or nil
+  local match_seach_pat = opts.search_pattern and gen_search_pat(opts.search_pattern) or nil
+
+  repeat
+    local current_dir = table.remove(next_dir, 1)
+    local fd = uv.fs_scandir(current_dir)
+    if fd == nil then break end
+    while true do
+      local name, typ = uv.fs_scandir_next(fd)
+      if name == nil then break end
+      process_item(opts, name, typ, current_dir, next_dir, base_paths, data, gitignore, match_seach_pat, callback)
+    end
+  until table.getn(next_dir) == 0
+  return data
+end
+
+--- m.scan_dir_async
+-- Search directory recursive and syncronous
+-- @param path: string or table
+--   string has to be a valid path
+--   table has to be a array of valid paths
+-- @param opts: table to change behavior
+--   opts.hidden (bool):              if true hidden files will be added
+--   opts.add_dirs (bool):            if true dirs will also be added to the results
+--   opts.respect_gitignore (bool):   if true will only add files that are not ignored by git
+--   opts.depth (int):                depth on how deep the search should go
+--   opts.search_pattern (lua regex): depth on how deep the search should go
+-- @param callback: table
+--   callback.on_stdout(entry): Will be called for each element
+--   callback.on_exit(content): Will be called at the end
+m.scan_dir_async = function(path, opts, callback)
+  callback = callback or {}
+  opts = opts or {}
+
+  local data = {}
+  local base_paths = vim.tbl_flatten { path }
+  local next_dir = vim.tbl_flatten{ path }
+  local current_dir = table.remove(next_dir, 1)
+
+  local gitignore = opts.respect_gitignore and get_gitignore() or nil
+  local match_seach_pat = opts.search_pattern and gen_search_pat(opts.search_pattern) or nil
+
+  local read_dir
+  read_dir = function(err, fd)
+    if not err then
+      while true do
+        local name, typ = uv.fs_scandir_next(fd)
+        if name == nil then break end
+        process_item(opts, name, typ, current_dir, next_dir, base_paths, data, gitignore, match_seach_pat, callback.on_stdout)
+      end
+      if table.getn(next_dir) == 0 then
+        if callback.on_exit then callback.on_exit(data) end
+      else
+        current_dir = table.remove(next_dir, 1)
+        uv.fs_scandir(current_dir, read_dir)
+      end
+    end
+  end
+  uv.fs_scandir(current_dir, read_dir)
+end
+
+local conv_to_octal = function(nr)
+  local octal = 0
+  local i = 1
+
+  while nr ~= 0 do
+    octal = octal + (nr % 8) * i
+    nr = math.floor(nr / 8)
+    i = i * 10
+  end
+
+  return octal;
+end
+
+local type_tbl = { [1]  = 'p', [2]  = 'c', [4]  = 'd', [6]  = 'b', [10] = '-', [12] = 'l', [14] = 's' }
+local permissions_tbl = { '--x', '-w-', '-wx', 'r--', 'r-x', 'rw-', 'rwx' }
+local bit_tbl = { 4, 2, 1 }
+
+local gen_permissions = function(stat)
+  local octal = string.format('%6d', conv_to_octal(stat.mode))
+  local l4 = octal:sub(#octal - 3, -1)
+  local bit = tonumber(l4:sub(1, 1))
+
+  local result = type_tbl[tonumber(octal:sub(1, 2))] or '-'
+  for i = 2, #l4 do
+    result = result .. permissions_tbl[tonumber(l4:sub(i, i))]
+    if bit - bit_tbl[i - 1] >= 0 then
+      result = result:sub(1, -2) .. (bit_tbl[i - 1] == 1 and 't' or 's')
+      bit = bit - bit_tbl[i - 1]
+    end
+  end
+  return result
+end
+
+local gen_size = function(stat)
+  local size = stat.size
+  for _, v in ipairs{ '', 'K', 'M', 'G', 'T', 'P', 'E', 'Z' } do
+    if math.abs(size) < 1024.0 then
+      if math.abs(size) > 9 then
+        return string.format("%3d%s", size, v)
+      else
+        return string.format("%3.1f%s", size, v)
+      end
+    end
+    size = size / 1024.0
+  end
+  return string.format("%.1f%s", size, 'Y')
+end
+
+local gen_date = function(stat)
+  return os.date('%b %d %H:%M', stat.mtime.sec)
+end
+
+local gen_id_cache = function(file)
+  if os_sep == '\\' then return nil end -- Don't have a user/group row for windows
+
+  local result = {}
+  local p = Path:new(file)
+  if not p:exists() then return nil end
+  for v in p:iter() do
+    if v ~= '' then
+      local el = vim.split(v, ':')
+      result[tonumber(el[3])] = el[1]
+    end
+  end
+
+  return result
+end
+
+local gen_ls = function(data, path)
+  local results = {}
+
+  local users_tbl = gen_id_cache('/etc/passwd')
+  local groups_tbl = gen_id_cache('/etc/group')
+
+  local insert_in_results
+  if not users_tbl and not groups_tbl then
+    insert_in_results = function(...)
+      local args = {...}
+      table.insert(results, string.format('%10s %5s  %s  %s', args[1], args[2], args[5], args[6]))
+    end
+  else
+    insert_in_results = function(...)
+      table.insert(results, string.format('%10s %5s %s %s  %s  %s', ...))
+    end
+  end
+
+  for _, v in ipairs(data) do
+    local stat = Path:new(v):_stat()
+
+    insert_in_results(
+      gen_permissions(stat),
+      gen_size(stat),
+      users_tbl and users_tbl[stat.uid] or nil,
+      groups_tbl and groups_tbl[stat.gid] or nil,
+      gen_date(stat),
+      v:sub(#path + 2, -1)
+    )
+  end
+  return results
+end
+
+--- m.ls
+-- List directory contents. Will always apply --long option.  Use scan_dir for without --long
+-- @param path: string
+--   string has to be a valid path
+-- @param opts: table to change behavior
+--   opts.hidden (bool):            if true hidden files will be added
+--   opts.add_dirs (bool):          if true dirs will also be added to the results, default: true
+--   opts.respect_gitignore (bool): if true will only add files that are not ignored by git
+--   opts.depth (int):              depth on how deep the search should go, default: 1
+-- @return array with formatted output
+m.ls = function(path, opts)
+  opts = opts or {}
+  opts.depth = opts.depth or 1
+  opts.add_dirs = opts.add_dirs or true
+  local data = m.scan_dir(path, opts)
+
+  return gen_ls(data, path)
+end
+
+--- m.ls_async
+-- List directory contents. Will always apply --long option. Use scan_dir for without --long
+-- @param path: string
+--   string has to be a valid path
+-- @param opts: table to change behavior
+--   opts.hidden (bool):            if true hidden files will be added
+--   opts.add_dirs (bool):          if true dirs will also be added to the results, default: true
+--   opts.respect_gitignore (bool): if true will only add files that are not ignored by git
+--   opts.depth (int):              depth on how deep the search should go, default: 1
+-- @param callback: function(results)
+m.ls_async = function(path, opts, callback)
+  opts = opts or {}
+  opts.depth = opts.depth or 1
+  opts.add_dirs = opts.add_dirs or true
+
+  m.scan_dir_async(path, opts, { on_exit = function(data)
+    callback(gen_ls(data, path))
+  end })
+end
+
+return m

--- a/tests/plenary/scandir_spec.lua
+++ b/tests/plenary/scandir_spec.lua
@@ -1,0 +1,154 @@
+local scan = require'plenary.scandir'
+local eq = assert.are.same
+
+local contains = function(tbl, str)
+  for _, v in ipairs(tbl) do
+    if v == str then return true end
+  end
+  return false
+end
+
+local contains_match = function(tbl, str)
+  for _, v in ipairs(tbl) do
+    if v:match(str) then return true end
+  end
+  return false
+end
+
+describe('scandir', function()
+  describe('can list all files recursive', function()
+    it('with cwd', function()
+      local dirs = scan.scan_dir('.')
+      eq('table', type(dirs))
+      eq(true, contains(dirs, './CHANGELOG.md'))
+      eq(true, contains(dirs, './LICENSE'))
+      eq(true, contains(dirs, './lua/plenary/job.lua'))
+      eq(false, contains(dirs, './asdf/asdf/adsf.lua'))
+    end)
+
+    it('and callback gets called for each entry', function()
+      local count = 0
+      local dirs = scan.scan_dir('.', nil, function() count = count + 1 end)
+      eq('table', type(dirs))
+      eq(true, contains(dirs, './CHANGELOG.md'))
+      eq(true, contains(dirs, './LICENSE'))
+      eq(true, contains(dirs, './lua/plenary/job.lua'))
+      eq(false, contains(dirs, './asdf/asdf/adsf.lua'))
+      eq(count, #dirs)
+    end)
+
+    it('with multiple paths', function()
+      local dirs = scan.scan_dir({ './lua' , './tests'})
+      eq('table', type(dirs))
+      eq(true, contains(dirs, './lua/say.lua'))
+      eq(true, contains(dirs, './lua/plenary/job.lua'))
+      eq(true, contains(dirs, './tests/plenary/scandir_spec.lua'))
+      eq(false, contains(dirs, './asdf/asdf/adsf.lua'))
+    end)
+
+    it('with hidden files', function()
+      local dirs = scan.scan_dir('.', { hidden = true })
+      eq('table', type(dirs))
+      eq(true, contains(dirs, './CHANGELOG.md'))
+      eq(true, contains(dirs, './lua/plenary/job.lua'))
+      eq(true, contains(dirs, './.gitignore'))
+      eq(false, contains(dirs, './asdf/asdf/adsf.lua'))
+    end)
+
+    it('with add directories', function()
+      local dirs = scan.scan_dir('.', { add_dirs = true })
+      eq('table', type(dirs))
+      eq(true, contains(dirs, './CHANGELOG.md'))
+      eq(true, contains(dirs, './lua/plenary/job.lua'))
+      eq(true, contains(dirs, './lua'))
+      eq(true, contains(dirs, './tests'))
+      eq(false, contains(dirs, './asdf/asdf/adsf.lua'))
+    end)
+
+    it('until depth 1 is reached', function()
+      local dirs = scan.scan_dir('.', { depth = 1 })
+      eq('table', type(dirs))
+      eq(true, contains(dirs, './CHANGELOG.md'))
+      eq(true, contains(dirs, './README.md'))
+      eq(false, contains(dirs, './lua'))
+      eq(false, contains(dirs, './lua/say.lua'))
+      eq(false, contains(dirs, './lua/plenary/job.lua'))
+      eq(false, contains(dirs, './asdf/asdf/adsf.lua'))
+    end)
+
+    it('until depth 1 is reached and with directories', function()
+      local dirs = scan.scan_dir('.', { depth = 1, add_dirs = true })
+      eq('table', type(dirs))
+      eq(true, contains(dirs, './CHANGELOG.md'))
+      eq(true, contains(dirs, './README.md'))
+      eq(true, contains(dirs, './lua'))
+      eq(false, contains(dirs, './lua/say.lua'))
+      eq(false, contains(dirs, './lua/plenary/job.lua'))
+      eq(false, contains(dirs, './asdf/asdf/adsf.lua'))
+    end)
+
+    it('until depth 2 is reached', function()
+      local dirs = scan.scan_dir('.', { depth = 2 })
+      eq('table', type(dirs))
+      eq(true, contains(dirs, './CHANGELOG.md'))
+      eq(true, contains(dirs, './README.md'))
+      eq(true, contains(dirs, './lua/say.lua'))
+      eq(false, contains(dirs, './lua/plenary/job.lua'))
+      eq(false, contains(dirs, './asdf/asdf/adsf.lua'))
+    end)
+
+    it('with respect_gitignore', function()
+      vim.cmd':silent !touch lua/test.so'
+      local dirs = scan.scan_dir('.', { respect_gitignore = true })
+      vim.cmd':silent !rm lua/test.so'
+      eq('table', type(dirs))
+      eq(true, contains(dirs, './CHANGELOG.md'))
+      eq(true, contains(dirs, './LICENSE'))
+      eq(true, contains(dirs, './lua/plenary/job.lua'))
+      eq(false, contains(dirs, './lua/test.so'))
+      eq(false, contains(dirs, './asdf/asdf/adsf.lua'))
+    end)
+
+    it('with search pattern', function()
+      local dirs = scan.scan_dir('.', { search_pattern = 'filetype' })
+      eq('table', type(dirs))
+      eq(true, contains(dirs, './scripts/update_filetypes_from_github.lua'))
+      eq(true, contains(dirs, './lua/plenary/filetype.lua'))
+      eq(true, contains(dirs, './tests/plenary/filetype_spec.lua'))
+      eq(true, contains(dirs, './data/plenary/filetypes/base.lua'))
+      eq(true, contains(dirs, './data/plenary/filetypes/builtin.lua'))
+      eq(false, contains(dirs, './README.md'))
+    end)
+  end)
+
+  describe('ls', function()
+    it('works for cwd', function()
+      local dirs = scan.ls('.')
+      eq('table', type(dirs))
+      eq(true, contains_match(dirs, 'CHANGELOG.md'))
+      eq(true, contains_match(dirs, 'LICENSE'))
+      eq(true, contains_match(dirs, 'README.md'))
+      eq(true, contains_match(dirs, 'lua'))
+      eq(false, contains_match(dirs, '%.git$'))
+    end)
+
+    it('works for another directory', function()
+      local dirs = scan.ls('./lua')
+      eq('table', type(dirs))
+      eq(true, contains_match(dirs, 'luassert'))
+      eq(true, contains_match(dirs, 'plenary'))
+      eq(true, contains_match(dirs, 'say.lua'))
+      eq(false, contains_match(dirs, 'README.md'))
+    end)
+
+    it('works with opts.hidden for cwd', function()
+      local dirs = scan.ls('.', { hidden = true })
+      eq('table', type(dirs))
+      eq(true, contains_match(dirs, 'CHANGELOG.md'))
+      eq(true, contains_match(dirs, 'LICENSE'))
+      eq(true, contains_match(dirs, 'README.md'))
+      eq(true, contains_match(dirs, 'lua'))
+      eq(true, contains_match(dirs, '%.git$'))
+    end)
+  end)
+end)

--- a/tests/plenary/scandir_spec.lua
+++ b/tests/plenary/scandir_spec.lua
@@ -28,7 +28,7 @@ describe('scandir', function()
 
     it('and callback gets called for each entry', function()
       local count = 0
-      local dirs = scan.scan_dir('.', nil, function() count = count + 1 end)
+      local dirs = scan.scan_dir('.', { on_insert = function() count = count + 1 end })
       eq('table', type(dirs))
       eq(true, contains(dirs, './CHANGELOG.md'))
       eq(true, contains(dirs, './LICENSE'))


### PR DESCRIPTION
todo:
- [x] respect gitignore
- [x] depth
- [x] search pattern
- [x] tests
- [x] Integrate into plenary.path
- [x] ls in lua
- [x] ls in lua async

Quick comparison with neovim repo (more will come) (all results are in seconds):
|               | fd       | rg --files | lua sync | lua async |
|---------------|----------|------------|----------|-----------|
| neovim/neovim | 0.004374 | 0.003067   | 0.004353 | 0.006484  |

current `m.ls` output from telescope with hidden:
```
drwxr-xr-x  4.0K conni conni  Jan 11 16:04  .git
drwxr-xr-x  4.0K conni conni  Jan 11 13:04  .github
-rw-r--r--   7.0 conni conni  Jan 11 13:04  .gitignore
-rw-r--r--   619 conni conni  Jan 11 13:04  .luacheckrc
-rw-r--r--  1.0K conni conni  Jan 11 13:04  LICENSE
-rw-r--r--   190 conni conni  Jan 11 13:04  Makefile
-rw-r--r--   33K conni conni  Jan 11 16:00  README.md
drwxr-xr-x  4.0K conni conni  Jan 11 13:04  data
-rw-r--r--  3.9K conni conni  Dec 19 19:41  feat.diff
drwxr-xr-x  4.0K conni conni  Jan 02 20:53  lua
drwxr-xr-x  4.0K conni conni  Sep 04 06:59  media
drwxr-xr-x  4.0K conni conni  Jan 11 13:04  plugin
drwxr-xr-x  4.0K conni conni  Jan 11 13:04  scratch
drwxr-xr-x  4.0K conni conni  Jan 11 13:04  scripts
-rw-r--r--  118K conni conni  Jan 10 13:32  tags
-rw-r--r--  2.4K conni conni  Dec 17 15:13  try_to_get_rid_of_prompt.diff
``` 

CC @tami5 