### PR TITLE
busted before_each and after_each

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ So far, the only supported busted items are:
 - `describe`
 - `it`
 - `pending`
+- `before_each`
+- `after_each`
+- `clear`
 - `assert.*` etc. (from luassert, which is bundled)
 
 OTHER NOTE:

--- a/lua/plenary/busted.lua
+++ b/lua/plenary/busted.lua
@@ -43,6 +43,8 @@ local mod = {}
 
 local results = {}
 local current_description = {}
+local current_before_each = {}
+local current_after_each = {}
 
 local add_description = function(desc)
   table.insert(current_description, desc)
@@ -54,14 +56,26 @@ local pop_description = function()
   current_description[#current_description] = nil
 end
 
+local add_new_each = function()
+  current_before_each[current_description[#current_description]] = {}
+  current_after_each[current_description[#current_description]] = {}
+end
+
+local clear_last_each = function()
+  current_before_each[current_description[#current_description]] = nil
+  current_after_each[current_description[#current_description]] = nil
+end
+
 local call_inner = function(desc, func)
   local desc_stack = add_description(desc)
+  add_new_each()
   local ok, msg = xpcall(func, function(msg)
     -- debug.traceback
     -- return vim.inspect(get_trace(nil, 3, msg))
     local trace = get_trace(nil, 3, msg)
     return trace.message .. "\n" .. trace.traceback
   end)
+  clear_last_each()
   pop_description()
 
   return ok, msg, desc_stack
@@ -148,6 +162,18 @@ mod.inner_describe = function(desc, func)
   end
 end
 
+mod.before_each = function(fn)
+  table.insert(current_before_each[current_description[#current_description]], fn)
+end
+
+mod.after_each = function(fn)
+  table.insert(current_after_each[current_description[#current_description]], fn)
+end
+
+mod.clear = function()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, {})
+end
+
 local indent = function(msg, spaces)
   if spaces == nil then
     spaces = 4
@@ -158,8 +184,18 @@ local indent = function(msg, spaces)
 
 end
 
+local run_each = function(tbl)
+  for _, v in pairs(tbl) do
+    for _, w in ipairs(v) do
+      if type(w) == 'function' then w() end
+    end
+  end
+end
+
 mod.it = function(desc, func)
+  run_each(current_before_each)
   local ok, msg, desc_stack = call_inner(desc, func)
+  run_each(current_after_each)
 
   local test_result = {
     descriptions = desc_stack,
@@ -195,6 +231,9 @@ _PlenaryBustedOldAssert = _PlenaryBustedOldAssert or assert
 describe = mod.describe
 it = mod.it
 pending = mod.pending
+before_each = mod.before_each
+after_each = mod.after_each
+clear = mod.clear
 assert = require("luassert")
 
 mod.run = function(file)

--- a/tests/plenary/simple_busted_spec.lua
+++ b/tests/plenary/simple_busted_spec.lua
@@ -1,3 +1,5 @@
+local eq = assert.are.same
+
 local tester_function = function()
   error(7)
 end
@@ -19,5 +21,83 @@ describe('busted specs', function()
 
   pending("Other thing", function()
     error()
+  end)
+
+  describe('befor each', function()
+    local a = 2
+    local b = 3
+    it('is not cleared', function()
+      eq(2, a)
+      eq(3, b)
+      a = a + 1
+      b = b + 1
+    end)
+    describe('nested', function()
+      before_each(function() a = 0 end)
+      it('should clear a but not b', function()
+        eq(0, a)
+        eq(4, b)
+        a = a + 1
+        b = b + 1
+      end)
+      describe('nested nested', function()
+        before_each(function() b = 0 end)
+        it('should clear b as well', function()
+          eq(0, a)
+          eq(0, b)
+          a = a + 1
+          b = b + 1
+        end)
+      end)
+      it('should only clear a', function()
+        eq(0, a)
+        eq(1, b)
+        a = a + 1
+        b = b + 1
+      end)
+    end)
+    it('should clear nothing', function()
+      eq(1, a)
+      eq(2, b)
+    end)
+  end)
+
+  describe('after each', function()
+    local a = 2
+    local b = 3
+    it('is not cleared', function()
+      eq(2, a)
+      eq(3, b)
+      a = a + 1
+      b = b + 1
+    end)
+    describe('nested', function()
+      after_each(function() a = 0 end)
+      it('should not clear any at this point', function()
+        eq(3, a)
+        eq(4, b)
+        a = a + 1
+        b = b + 1
+      end)
+      describe('nested nested', function()
+        after_each(function() b = 0 end)
+        it('should have cleared a', function()
+          eq(0, a)
+          eq(5, b)
+          a = a + 1
+          b = b + 1
+        end)
+      end)
+      it('should have cleared a and b', function()
+        eq(0, a)
+        eq(0, b)
+        a = a + 1
+        b = b + 1
+      end)
+    end)
+    it('should only have cleared a', function()
+      eq(0, a)
+      eq(1, b)
+    end)
   end)
 end)


### PR DESCRIPTION
Just a sketch. ~~I probably need to do something a little smarter. But i am tired right now, so i will finish it tomorrow :)~~

Edit: `after_each` could also be helpful. Any thoughts tj? Or whats suggested here: https://github.com/nvim-lua/plenary.nvim/issues/49#issuecomment-761623782

Thats the idea, because tami asked 😆 :
```lua
describe('main', function()
  it('stuff 0', function() end) -- will not run any before_each
  describe('nested', function()
    before_each(clear)
    it('stuff 1', function() end) -- will run clear
    describe('nested nested', function()
      before_each(del_db)
      it('stuff 2', function() end) -- will run clear and del_db
    end)
    it('stuff 3', function() end) -- will run clear
  end)
  it('stuff 4', function() end) -- will not run any before_each
end)
```