### PR TITLE
telescope #369: added stack traceback for no finder

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -76,6 +76,10 @@ function Job:new(o)
     error(debug.traceback("'command' is required for Job:new"))
   end
 
+  if 1 ~= vim.fn.executable(o.command) then
+    error(debug.traceback(o.command..": Executable not found"))
+  end
+
   local obj = {}
 
   obj.command = o.command

--- a/tests/plenary/job_spec.lua
+++ b/tests/plenary/job_spec.lua
@@ -520,9 +520,7 @@ describe('Job', function()
     end)
 
     it('will not spawn jobs with invalid commands', function()
-      local job = Job:new { command = 'dasowlwl' }
-
-      local ok = pcall(job.sync, job)
+      local ok = pcall(Job.new, Job, { command = 'dasowlwl' })
       assert(not ok, "Should not allow invalid executables")
     end)
   end)


### PR DESCRIPTION
Check if o.command exists before creating a new job. If not adds a debug traceback. Example: "rg: Executable not found"