### PR TITLE
Add functions from telescope.path

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -232,20 +232,19 @@ function Path:normalize()
 end
 
 local shorten = (function()
-  if jit then return function(filename)
-    local ffi = require('ffi')
-    ffi.cdef [[
+  if jit then
+    local ffi = require('ffi') ffi.cdef [[
     typedef unsigned char char_u;
     char_u *shorten_dir(char_u *str);
     ]]
+    return function(filename)
+      if not filename then
+        return filename
+      end
 
-    if not filename then
-      return filename
-    end
-
-    local c_str = ffi.new("char[?]", #filename + 1)
-    ffi.copy(c_str, filename)
-    return ffi.string(ffi.C.shorten_dir(c_str))
+      local c_str = ffi.new("char[?]", #filename + 1)
+      ffi.copy(c_str, filename)
+      return ffi.string(ffi.C.shorten_dir(c_str))
     end
   end
   return function(filename)

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -229,7 +229,6 @@ function Path:normalize(cwd)
   self.filename = self.filename:gsub("^" .. path.home, '~', 1)
   -- Remove double path seps, it's annoying
   self.filename = self.filename:gsub(path.sep .. path.sep, path.sep)
-  print(self.filename)
 
   return self.filename
 end

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -402,7 +402,7 @@ end
 
 -- TODO: Asyncify this and use vim.wait in the meantime.
 --  This will allow other events to happen while we're waiting!
-function Path:read()
+function Path:_read()
   self = check_self(self)
 
   local fd = assert(uv.fs_open(self:expand(), "r", 438)) -- for some reason test won't pass with absolute
@@ -413,7 +413,7 @@ function Path:read()
   return data
 end
 
-function Path:read_async(callback)
+function Path:_read_async(callback)
   vim.loop.fs_open(self.filename, "r", 438, function(err_open, fd)
     if err_open then
       print("We tried to open this file but couldn't. We failed with following error message: " .. err_open)
@@ -431,6 +431,13 @@ function Path:read_async(callback)
       end)
     end)
   end)
+end
+
+function Path:read(callback)
+  if callback then
+    return self:_read_async(callback)
+  end
+  return self:_read()
 end
 
 function Path:head(lines)

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -15,6 +15,7 @@ local S_IF = {
   -- S_IFREG  = 0o100000  # regular file
   REG = 0x8000,
 }
+
 local path = {}
 path.home = vim.loop.os_homedir()
 

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -412,8 +412,8 @@ function Path:read()
   return data
 end
 
-function Path:read_async(filepath, callback)
-  vim.loop.fs_open(filepath, "r", 438, function(err_open, fd)
+function Path:read_async(callback)
+  vim.loop.fs_open(self.filename, "r", 438, function(err_open, fd)
     if err_open then
       print("We tried to open this file but couldn't. We failed with following error message: " .. err_open)
       return

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -206,22 +206,24 @@ function Path:expand()
   return expanded and expanded or error("Path not valid")
 end
 
-function Path:make_relative()
-  if self.filename:sub(1, #self._cwd) == self._cwd  then
+function Path:make_relative(cwd)
+  cwd = F.if_nil(cwd, self._cwd, cwd)
+  if self.filename:sub(1, #cwd) == cwd  then
     local offset =  0
-    -- if  self._cwd does ends in the os separator, we need to take it off
-    if self._cwd:sub(#self._cwd, #self._cwd) ~= path.separator then
+    -- if  cwd does ends in the os separator, we need to take it off
+    if cwd:sub(#cwd, #cwd) ~= path.separator then
       offset = 1
     end
 
-    self.filename = self.filename:sub(#self._cwd + 1 + offset, #self.filename)
+    self.filename = self.filename:sub(#cwd + 1 + offset, #self.filename)
   end
 
   return self.filename
 end
 
-function Path:normalize()
-  self:make_relative()
+function Path:normalize(cwd)
+  cwd = F.if_nil(cwd, self._cwd, cwd)
+  self:make_relative(cwd)
   -- Substitute home directory w/ "~"
   self.filename = self.filename:gsub("^" .. path.home, '~', 1)
   -- Remove double path seps, it's annoying

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -16,7 +16,7 @@ local S_IF = {
   REG = 0x8000,
 }
 local path = {}
-path.home = vim.fn.expand('~')
+path.home = vim.loop.os_homedir()
 
 path.sep = (function()
   if string.lower(jit.os) == 'linux' or string.lower(jit.os) == 'osx' then

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -93,6 +93,35 @@ describe('Path', function()
     end)
   end)
 
+  describe(':make_relative', function()
+    it('can take absoluate paths and make them relative to the cwd', function()
+      local absolute = vim.fn.getcwd() .. '/lua/plenary/path.lua'
+      local relative = Path:new(absolute):make_relative()
+      assert.are.same(relative, 'lua/plenary/path.lua')
+    end)
+
+    it('can take absoluate paths and make them relative to a given path', function()
+      local absolute = vim.fn.getcwd() .. '/lua/plenary/path.lua'
+      local relative = Path:new(absolute):make_relative(vim.fn.getcwd() .. '/lua')
+      assert.are.same(relative, 'plenary/path.lua')
+    end)
+  end)
+
+  describe(':normalize', function()
+    it('can take paths with double separators change them to single separators', function()
+      local orig = 'lua//plenary/path.lua'
+      local final = Path:new(orig):normalize()
+      assert.are.same(final, 'lua/plenary/path.lua')
+    end)
+    -- this may be redundant since normalize just calls make_relative which is tested above
+    it('can take absolute paths with double seps'
+      .. 'and make them relative with single seps', function()
+      local orig = vim.fn.getcwd() .. '/lua//plenary/path.lua'
+      local final = Path:new(orig):normalize()
+      assert.are.same(final, 'lua/plenary/path.lua')
+    end)
+  end)
+
   describe('mkdir / rmdir', function()
     it('can create and delete directories', function()
       local p = Path:new("_dir_not_exist")

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -95,14 +95,14 @@ describe('Path', function()
 
   describe(':make_relative', function()
     it('can take absoluate paths and make them relative to the cwd', function()
-      local absolute = vim.fn.getcwd() .. '/lua/plenary/path.lua'
+      local absolute = vim.loop.cwd() .. '/lua/plenary/path.lua'
       local relative = Path:new(absolute):make_relative()
       assert.are.same(relative, 'lua/plenary/path.lua')
     end)
 
     it('can take absoluate paths and make them relative to a given path', function()
-      local absolute = vim.fn.getcwd() .. '/lua/plenary/path.lua'
-      local relative = Path:new(absolute):make_relative(vim.fn.getcwd() .. '/lua')
+      local absolute = vim.loop.cwd() .. '/lua/plenary/path.lua'
+      local relative = Path:new(absolute):make_relative(vim.loop.cwd() .. '/lua')
       assert.are.same(relative, 'plenary/path.lua')
     end)
   end)
@@ -116,7 +116,7 @@ describe('Path', function()
     -- this may be redundant since normalize just calls make_relative which is tested above
     it('can take absolute paths with double seps'
       .. 'and make them relative with single seps', function()
-      local orig = vim.fn.getcwd() .. '/lua//plenary/path.lua'
+      local orig = vim.loop.cwd() .. '/lua//plenary/path.lua'
       local final = Path:new(orig):normalize()
       assert.are.same(final, 'lua/plenary/path.lua')
     end)


### PR DESCRIPTION
I'm working on moving telescope to use `plenary.path` instead of its own path module (see [this issue](https://github.com/nvim-telescope/telescope.nvim/issues/387)) and found that there were some functions missing in plenary.

Functions I added:
-  `Path:normalize`
-  `Path:make_relative`
-  `Path:read_async`

I also added the property `home` to `Path.path`, which is simply the user's home directory. It can probably be used in places other than the functions for which I added it, but I did not go through and apply it in those spots yet.

CC @Conni2461 