### PR TITLE
Add more filetypes for filetype detector

### DIFF
--- a/data/plenary/filetypes/builtin.lua
+++ b/data/plenary/filetypes/builtin.lua
@@ -18,6 +18,8 @@ end
 
 return {
   extension = {
+    ['ex'] = 'elixir',
+    ['exs'] = 'elixir',
     ['plist'] = 'xml',
     ['gradle'] = 'groovy',
     ['kt'] = 'kotlin',

--- a/data/plenary/filetypes/builtin.lua
+++ b/data/plenary/filetypes/builtin.lua
@@ -18,6 +18,9 @@ end
 
 return {
   extension = {
+    ['plist'] = 'xml',
+    ['gradle'] = 'groovy',
+    ['kt'] = 'kotlin',
     ['dart'] = 'dart',
     ['fnl'] = 'fennel',
     ['janet'] = 'janet',

--- a/data/plenary/filetypes/builtin.lua
+++ b/data/plenary/filetypes/builtin.lua
@@ -18,6 +18,7 @@ end
 
 return {
   extension = {
+    ['dart'] = 'dart',
     ['fnl'] = 'fennel',
     ['janet'] = 'janet',
     ['jsx'] = 'javascriptreact',


### PR DESCRIPTION
This adds `dart`,`kotlin`,`gradle/groovy`,`plist` files to the list of filetypes used for detection so it can be recognised correctly by `telescope`'s buffer previewers.