### PR TITLE
Introduces a range of `and_then` and `after` function that will handle callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,33 @@ Plug 'nvim-lua/plenary.nvim'
 
 ## Modules
 
+- `plenary.job`
 - `plenary.path`
 - `plenary.context_manager`
 - `plenary.test_harness`
 - `plenary.neorocks` (This may move to packer.nvim, but I have added some improvements to use it more as a library.)
+
+### plenary.job
+
+A Lua module to interactive with system processes. Pass in your `command`, the desired `args`, `env` and `cwd`.
+Define optional callbacks for `on_stdout`, `on_stderr` and `on_exit` and `start` your Job.
+
+Note: Each job has an empty environment.
+
+```lua
+local Job = require'plenary.job'
+
+Job:new({
+  command = 'rg',
+  args = { '--files' },
+  cwd = '/usr/bin',
+  env = { ['a'] = 'b' },
+  on_exit = function(j, return_val)
+    print(return_val)
+    print(j:result())
+  end,
+}):sync() -- or start()
+```
 
 ### plenary.path
 


### PR DESCRIPTION
Builds on top of your previous work for `and_then`. We might also wanna change `chain` i my opinion it has the even better interface to do that.

None of these additions are necessary but after i saw @tami5 code it might be helpful. tami is currently in the `on_exit` callback hell which makes maintaining his work a nightmare, no offense tami :). This might help writing jobs that go from job to job easier.
Example at the end. For me that is easier to read and i actually know when which job does what and what the conditions are for that case to happen. Does this make sense? We do not need to integrate it :)
I only want that `sync` returns the result code. Thats the only thing that interests me tbh :rofl: Saves me one line in telescope.

Adds:
- `sync` will now return `code` as second return value
- `and_then(job)`: will always run job
- `and_then_wrap(job)`: will always run job (schedule_wrapped)
- `and_then_on_success(job)`: will only run job if code == 0
- `and_then_on_success_wrap(job)`: will only run job if code == 0 (schedule_wrapped)
- `and_then_on_failure(job)`: will only run job if code ~= 0
- `and_then_on_failure_wrap(job)`: will only run job if code ~= 0 (schedule_wrapped)
- `after(fn)`: will always run function
- `after_success(fn)`: will only run function if code == 0
- `after_failure(fn)`: will only run function if code ~= 0

Example:
```lua
local gen_j1 = function()
  -- only generate the job outline no callbacks
end
-- ... gen_j2 -> gen_j4 exist

local run = function()
  local j1 = gen_j1()
  local j2 = gen_j2()
  local j3 = gen_j3()
  
  j1:after_failure(function(j, code) log.trace(j:result, code) end)
  j1:and_then_on_success(j2)
  j2:after_failure(function() ... end)
  j2:and_then_on_success(j3)
  -- etc 
  j3:start()
end
```