### PR TITLE
Add configuration variable to disable neorocks setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ neorocks.ensure_installed('lua-cjson', 'cjson')
 
 Inspiration: https://github.com/theHamsta/nvim_rocks . However, I've used quite a different end goal (following XDG_CONFIG standards, using `package.path` and `package.cpath` to load the packages and a different strategy of loading).
 
+You may disable `neorocks` if necessary (e.g. if you are using another Luarocks provider and don't want to pay the startup cost of `neorocks` setup) by setting `g:plenary_disable_neorocks = v:true`.
 
 ### Bundled with:
 

--- a/plugin/plenary.vim
+++ b/plugin/plenary.vim
@@ -1,6 +1,8 @@
 
 " Set up neorocks if it is installed.
-lua pcall(function() require('plenary.neorocks').setup_paths() end)
+if !exists('g:plenary_disable_neorocks')
+  lua pcall(function() require('plenary.neorocks').setup_paths() end)
+endif
 
 " Create command for running busted
 command! -nargs=1 -complete=file PlenaryBustedFile


### PR DESCRIPTION
As the `neorocks` setup in `plugin/plenary.vim` has a startup time cost of ~5ms (on my system), I thought it might be useful to add a configuration variable, `g:plenary_disable_neorocks`, to optionally skip this setup.