### PR TITLE
busted: fix for multiple top level describes

### DIFF
--- a/lua/plenary/busted.lua
+++ b/lua/plenary/busted.lua
@@ -120,35 +120,16 @@ mod.format_results = function(res)
 end
 
 mod.describe = function(desc, func)
-  results.pass = {}
-  results.fail = {}
-  results.errs = {}
-
-  print("\n" .. HEADER)
-  print("Testing: ", debug.getinfo(2, 'Sl').source)
+  results.pass  = results.pass or {}
+  results.fail  = results.fail or {}
+  results.errs  = results.errs or {}
+  results.fatal = results.fatal or {}
 
   describe = mod.inner_describe
   local ok, msg = call_inner(desc, func)
   describe = mod.describe
 
-  mod.format_results(results)
-
-  if not ok then
-    print("We had an unexpected error: ", msg, vim.inspect(results))
-    if is_headless then
-      os.exit(2)
-    end
-  elseif #results.fail > 0 then
-    print("Tests Failed. Exit: 1")
-
-    if is_headless then
-      os.exit(1)
-    end
-  else
-    if is_headless then
-      os.exit(0)
-    end
-  end
+  table.insert(results.fatal, msg)
 end
 
 mod.inner_describe = function(desc, func)
@@ -221,9 +202,9 @@ mod.it = function(desc, func)
 end
 
 mod.pending = function(desc, func)
-  -- local _, _, desc_stack = call_inner(desc, func)
-  -- print(PENDING, "||", table.concat(desc_stack, " "))
-  print(PENDING, "||", desc)
+  local curr_stack = vim.deepcopy(current_description)
+  table.insert(curr_stack, desc)
+  print(PENDING, "||", table.concat(curr_stack, " "))
 end
 
 _PlenaryBustedOldAssert = _PlenaryBustedOldAssert or assert
@@ -238,6 +219,9 @@ clear = mod.clear
 assert = require("luassert")
 
 mod.run = function(file)
+  print("\n" .. HEADER)
+  print("Testing: ", file)
+
   local ok, msg = pcall(dofile, file)
 
   if not ok then
@@ -245,10 +229,40 @@ mod.run = function(file)
     print("FAILED TO LOAD FILE")
     print(color_string("red", msg))
     print(HEADER)
-    os.exit(2)
+    if is_headless then
+      os.exit(2)
+    else
+      return
+    end
   end
 
-  os.exit(0)
+  -- If nothing runs (empty file without top level describe)
+  if not results.pass then
+    if is_headless then
+      os.exit(0)
+    else
+      return
+    end
+  end
+
+  mod.format_results(results)
+
+  if #results.fatal ~= 0 then
+    print("We had an unexpected error: ", vim.inspect(results.fatal), vim.inspect(results))
+    if is_headless then
+      os.exit(2)
+    end
+  elseif #results.fail > 0 then
+    print("Tests Failed. Exit: 1")
+
+    if is_headless then
+      os.exit(1)
+    end
+  else
+    if is_headless then
+      os.exit(0)
+    end
+  end
 end
 
 return mod

--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -491,11 +491,18 @@ end
 --- Wait for all jobs to complete
 function Job.join(...)
   local jobs_to_wait = {...}
+  local num_jobs = table.getn(jobs_to_wait)
 
-  local num_jobs = #jobs_to_wait
+  -- last entry can be timeout
+  local timeout
+  if type(jobs_to_wait[num_jobs]) == "number" then
+    timeout = table.remove(jobs_to_wait, num_jobs)
+    num_jobs = num_jobs - 1
+  end
+
   local completed = 0
 
-  return vim.wait(10000, function()
+  return vim.wait(timeout or 10000, function()
     for index, current_job in pairs(jobs_to_wait) do
       if current_job.is_shutdown then
         jobs_to_wait[index] = nil

--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -123,8 +123,10 @@ function harness.test_directory(directory, opts)
     return
   end
 
+  table.insert(jobs, 50000)
   log.debug("...Waiting")
   Job.join(unpack(jobs))
+  table.remove(jobs, table.getn(jobs))
   vim.wait(100)
   log.debug("Done...")
 

--- a/tests/plenary/simple_busted_spec.lua
+++ b/tests/plenary/simple_busted_spec.lua
@@ -19,85 +19,91 @@ describe('busted specs', function()
     pcall(tester_function)
   end)
 
-  pending("Other thing", function()
+  pending("other thing pending", function()
     error()
   end)
+end)
 
-  describe('befor each', function()
-    local a = 2
-    local b = 3
-    it('is not cleared', function()
-      eq(2, a)
-      eq(3, b)
-      a = a + 1
-      b = b + 1
-    end)
-    describe('nested', function()
-      before_each(function() a = 0 end)
-      it('should clear a but not b', function()
-        eq(0, a)
-        eq(4, b)
-        a = a + 1
-        b = b + 1
-      end)
-      describe('nested nested', function()
-        before_each(function() b = 0 end)
-        it('should clear b as well', function()
-          eq(0, a)
-          eq(0, b)
-          a = a + 1
-          b = b + 1
-        end)
-      end)
-      it('should only clear a', function()
-        eq(0, a)
-        eq(1, b)
-        a = a + 1
-        b = b + 1
-      end)
-    end)
-    it('should clear nothing', function()
-      eq(1, a)
-      eq(2, b)
-    end)
+describe('before each', function()
+  local a = 2
+  local b = 3
+  it('is not cleared', function()
+    eq(2, a)
+    eq(3, b)
+    a = a + 1
+    b = b + 1
   end)
-
-  describe('after each', function()
-    local a = 2
-    local b = 3
-    it('is not cleared', function()
-      eq(2, a)
-      eq(3, b)
+  describe('nested', function()
+    before_each(function() a = 0 end)
+    it('should clear a but not b', function()
+      eq(0, a)
+      eq(4, b)
       a = a + 1
       b = b + 1
     end)
-    describe('nested', function()
-      after_each(function() a = 0 end)
-      it('should not clear any at this point', function()
-        eq(3, a)
-        eq(4, b)
-        a = a + 1
-        b = b + 1
-      end)
-      describe('nested nested', function()
-        after_each(function() b = 0 end)
-        it('should have cleared a', function()
-          eq(0, a)
-          eq(5, b)
-          a = a + 1
-          b = b + 1
-        end)
-      end)
-      it('should have cleared a and b', function()
+    describe('nested nested', function()
+      before_each(function() b = 0 end)
+      it('should clear b as well', function()
         eq(0, a)
         eq(0, b)
         a = a + 1
         b = b + 1
       end)
     end)
-    it('should only have cleared a', function()
+    it('should only clear a', function()
       eq(0, a)
       eq(1, b)
+      a = a + 1
+      b = b + 1
     end)
+  end)
+  it('should clear nothing', function()
+    eq(1, a)
+    eq(2, b)
+  end)
+end)
+
+describe('after each', function()
+  local a = 2
+  local b = 3
+  it('is not cleared', function()
+    eq(2, a)
+    eq(3, b)
+    a = a + 1
+    b = b + 1
+  end)
+  describe('nested', function()
+    after_each(function() a = 0 end)
+    it('should not clear any at this point', function()
+      eq(3, a)
+      eq(4, b)
+      a = a + 1
+      b = b + 1
+    end)
+    describe('nested nested', function()
+      after_each(function() b = 0 end)
+      it('should have cleared a', function()
+        eq(0, a)
+        eq(5, b)
+        a = a + 1
+        b = b + 1
+      end)
+    end)
+    it('should have cleared a and b', function()
+      eq(0, a)
+      eq(0, b)
+      a = a + 1
+      b = b + 1
+    end)
+  end)
+  it('should only have cleared a', function()
+    eq(0, a)
+    eq(1, b)
+  end)
+end)
+
+describe('fourth top level describe test', function()
+  it('should work', function()
+    eq(1, 1)
   end)
 end)


### PR DESCRIPTION
Currently only one top level describe is possible. We talked about that already. That should fix it.
Also pending will also print the current stack now not only the message.

Also also i moved some of the before and after each in its own top level describe block and added a fourth one for testing. So it should work :)

~~Edit: The fatal thing is not working so i gotta fix that first :rofl:~~

I am not so sure if i like the new fatal handling so far. Maybe we should just do if `inner` not okay then print error and stop execution.

~~Also we are running into this issue where all tests are passing but we are still returning 1 or 2 and it seems like now its more present.~~ I fixed that by having `Job:join` accept a timeout as last param and setting that to 50000. Can't have it behind the unpack. So inserting and removing in the job table makes it work.