### PR TITLE
Prefer vim.api over vim.fn

### DIFF
--- a/lua/plenary/nvim_meta.lua
+++ b/lua/plenary/nvim_meta.lua
@@ -12,7 +12,7 @@ end
 
 return {
   -- Is run in `--headless` mode.
-  is_headless = (#vim.fn.nvim_list_uis() == 0),
+  is_headless = (#vim.api.nvim_list_uis() == 0),
 
   lua_jit = get_lua_version(),
 }

--- a/lua/plenary/popup.lua
+++ b/lua/plenary/popup.lua
@@ -34,11 +34,11 @@ function popup.popup_create(what, vim_options)
   if type(what) == 'number' then
     bufnr = what
   else
-    bufnr = vim.fn.nvim_create_buf(false, true)
+    bufnr = vim.api.nvim_create_buf(false, true)
     assert(bufnr, "Failed to create buffer")
 
     -- TODO: Handle list of lines
-    vim.fn.nvim_buf_set_lines(bufnr, 0, -1, true, {what})
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, {what})
   end
 
   local option_defaults = {
@@ -128,7 +128,7 @@ function popup.popup_create(what, vim_options)
   if vim_options.hidden then
     assert(false, "I have not implemented this yet and don't know how")
   else
-    win_id = vim.fn.nvim_open_win(bufnr, true, win_opts)
+    win_id = vim.api.nvim_open_win(bufnr, true, win_opts)
   end
 
 
@@ -152,13 +152,13 @@ function popup.popup_create(what, vim_options)
   if vim_options.time then
     local timer = vim.loop.new_timer()
     timer:start(vim_options.time, 0, vim.schedule_wrap(function()
-      vim.fn.nvim_close_win(win_id, false)
+      vim.api.nvim_close_win(win_id, false)
     end))
   end
 
   -- Buffer Options
   if vim_options.cursorline then
-    vim.fn.nvim_win_set_option(0, 'cursorline', true)
+    vim.api.nvim_win_set_option(0, 'cursorline', true)
   end
 
   -- vim.fn.nvim_win_set_option(0, 'wrap', dict_default(vim_options, 'wrap', option_defaults))

--- a/lua/plenary/window/float.lua
+++ b/lua/plenary/window/float.lua
@@ -47,11 +47,11 @@ function win_float.centered(options)
 
   local win_opts = win_float.default_opts(options)
 
-  local bufnr = options.bufnr or vim.fn.nvim_create_buf(false, true)
-  local win_id = vim.fn.nvim_open_win(bufnr, true, win_opts)
+  local bufnr = options.bufnr or vim.api.nvim_create_buf(false, true)
+  local win_id = vim.api.nvim_open_win(bufnr, true, win_opts)
 
   vim.cmd('setlocal nocursorcolumn')
-  vim.fn.nvim_win_set_option(win_id, 'winblend', options.winblend)
+  vim.api.nvim_win_set_option(win_id, 'winblend', options.winblend)
 
   vim.cmd(
     string.format(
@@ -84,15 +84,15 @@ function win_float.centered_with_top_win(top_text, options)
   local minor_win_id = vim.api.nvim_open_win(minor_bufnr, true, minor_win_opts)
 
   vim.cmd('setlocal nocursorcolumn')
-  vim.fn.nvim_win_set_option(minor_win_id, 'winblend', options.winblend)
+  vim.api.nvim_win_set_option(minor_win_id, 'winblend', options.winblend)
 
   vim.api.nvim_buf_set_lines(minor_bufnr, 0, -1, false, top_text)
 
-  local primary_bufnr = vim.fn.nvim_create_buf(false, true)
-  local primary_win_id = vim.fn.nvim_open_win(primary_bufnr, true, primary_win_opts)
+  local primary_bufnr = vim.api.nvim_create_buf(false, true)
+  local primary_win_id = vim.api.nvim_open_win(primary_bufnr, true, primary_win_opts)
 
   vim.cmd('setlocal nocursorcolumn')
-  vim.fn.nvim_win_set_option(primary_win_id, 'winblend', options.winblend)
+  vim.api.nvim_win_set_option(primary_win_id, 'winblend', options.winblend)
 
   -- vim.cmd(
   --   string.format(
@@ -175,12 +175,12 @@ function win_float.percentage_range_window(col_range, row_range, options)
   win_opts.col = math.floor(vim.o.columns * col_start_percentage)
   win_opts.width = math.floor(vim.o.columns * width_percentage)
 
-  local bufnr = options.bufnr or vim.fn.nvim_create_buf(false, true)
-  local win_id = vim.fn.nvim_open_win(bufnr, true, win_opts)
+  local bufnr = options.bufnr or vim.api.nvim_create_buf(false, true)
+  local win_id = vim.api.nvim_open_win(bufnr, true, win_opts)
   vim.api.nvim_win_set_buf(win_id, bufnr)
 
   vim.cmd('setlocal nocursorcolumn')
-  vim.fn.nvim_win_set_option(win_id, 'winblend', options.winblend)
+  vim.api.nvim_win_set_option(win_id, 'winblend', options.winblend)
 
   local border = Border:new(bufnr, win_id, win_opts, {})
 
@@ -204,7 +204,7 @@ function win_float.clear(bufnr)
 
   for _, win_id in ipairs(_AssociatedBufs[bufnr]) do
     if vim.api.nvim_win_is_valid(win_id) then
-      vim.fn.nvim_win_close(win_id, true)
+      vim.api.nvim_win_close(win_id, true)
     end
   end
 

--- a/scratch/window_test.lua
+++ b/scratch/window_test.lua
@@ -5,31 +5,31 @@ function CanWinBeHidden()
   -- Just keep track of the buffer ID
 
   local what = "test string"
-  local bufnr = vim.fn.nvim_create_buf(false, true)
+  local bufnr = vim.api.nvim_create_buf(false, true)
 
   -- TODO: Handle list of lines
-  vim.fn.nvim_buf_set_lines(bufnr, 0, -1, true, {what})
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, {what})
 
-  local win_id = vim.fn.nvim_open_win(bufnr, true, {relative='win', row=3, col=3, width=40, height=3})
-  vim.fn.nvim_win_close(win_id, false)
+  local win_id = vim.api.nvim_open_win(bufnr, true, {relative='win', row=3, col=3, width=40, height=3})
+  vim.api.nvim_win_close(win_id, false)
 end
 
 
 function CanWinBeReordered()
   what = "test string"
-  buf_text = vim.fn.nvim_create_buf(false, true)
+  buf_text = vim.api.nvim_create_buf(false, true)
 
-  buf_border = vim.fn.nvim_create_buf(false, true)
+  buf_border = vim.api.nvim_create_buf(false, true)
 
   -- TODO: Handle list of lines
-  vim.fn.nvim_buf_set_lines(buf_text, 0, -1, true, {what})
-  vim.fn.nvim_buf_set_lines(buf_border, 0, -1, true, {"====", "", "====="})
+  vim.api.nvim_buf_set_lines(buf_text, 0, -1, true, {what})
+  vim.api.nvim_buf_set_lines(buf_border, 0, -1, true, {"====", "", "====="})
 
-  win_text = vim.fn.nvim_open_win(buf_text, false, {relative='win', row=3, col=3, width=40, height=1})
-  win_border = vim.fn.nvim_open_win(buf_border, false, {relative='win', row=2, col=3, width=40, height=3})
+  win_text = vim.api.nvim_open_win(buf_text, false, {relative='win', row=3, col=3, width=40, height=1})
+  win_border = vim.api.nvim_open_win(buf_border, false, {relative='win', row=2, col=3, width=40, height=3})
 
-  vim.fn.nvim_win_close(win_text, false)
-  vim.fn.nvim_win_close(win_border, false)
+  vim.api.nvim_win_close(win_text, false)
+  vim.api.nvim_win_close(win_border, false)
 
   current_win_id = vim.fn.win_getid()
   _ = {vim.fn.win_gotoid(win_text), vim.cmd("sleep 100m"), vim.fn.win_gotoid(current_win_id)}


### PR DESCRIPTION
Now that https://github.com/neovim/neovim/pull/13875 is merged, using `vim.fn` when the same function exists in `vim.api` causes an error. I _think_ this PR updates everything that needs to be fixed, but I'm not 100% certain.