### PR TITLE
path.lua: use correct path separator on BSD operating systems.

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -21,7 +21,8 @@ path.home = vim.loop.os_homedir()
 
 path.sep = (function()
   if jit then
-    if string.lower(jit.os) == 'linux' or string.lower(jit.os) == 'osx' then
+    local os = string.lower(jit.os)
+    if os == 'linux' or os == 'osx' or os == 'bsd' then
       return '/'
     else
       return '\\'


### PR DESCRIPTION
When using the `Telescope file_browser`, plenary returns the incorrect path separator for BSD operating systems, fix that.

`jit.os` is `BSD` on FreeBSD, take this into account when returning the path separator.

Tested on FreeBSD.