### PR TITLE
magical imports and setting function environments

### DIFF
--- a/lua/plenary/import.lua
+++ b/lua/plenary/import.lua
@@ -1,0 +1,75 @@
+local function validate_opts(opts)
+  vim.validate {
+    to_import = {
+      opts[1],
+      function(to_import)
+        return type(to_import) == "nil" or type(to_import) == "string"
+      end,
+      'nil or string',
+    },
+    from = {
+      opts.from,
+      function(from)
+        return type(from) == "table" or type(from) == "string"
+      end,
+      'table or string'
+    },
+  }
+
+  if opts.fresh then
+    vim.validate {
+      fresh = {opts.fresh, 'boolean'}
+    }
+  end
+
+  if opts.into then
+    vim.validate {
+      into = {
+        opts.into,
+        function(into)
+          return type(into) == "function" or type(into) == "number"
+        end,
+        'number or string',
+      }
+    }
+  end
+end
+
+local function import(opts)
+  opts = opts or {}
+
+  validate_opts(opts)
+
+  local to_import = opts[1]
+
+  local env = opts.fresh and {} or getfenv(2)
+
+  local exports
+  if type(opts.from) == "table" then
+    exports = opts.from
+  else
+    exports = require(opts.from)
+  end
+
+  if to_import == "*" then
+    for name, export in pairs(exports) do
+      if opts.override == false then
+        assert(not env[name], "Overriding something with name " .. name)
+      end
+      env[name] = export
+    end
+  elseif type(to_import) == "string" then
+    if opts.override == false then
+      assert(not env[to_import], "Overriding something with name " .. to_import)
+    end
+    env[to_import] = exports[to_import]
+  end
+
+  if opts.as then
+    env[opts.as] = exports
+  end
+
+  setfenv(opts.into or 2, env)
+end
+
+return import

--- a/tests/plenary/import_spec.lua
+++ b/tests/plenary/import_spec.lua
@@ -1,17 +1,15 @@
-local eq = assert.are.same
+local import = require('plenary.import')
+
+local eq = assert.are
 
 describe('import', function()
   it('should be able to glob import', function()
-    local import = require('plenary.import')
-
     import { "*", from = "plenary.filetype" }
 
     assert(type(_get_extension_parts), "function")
   end)
 
   it('should be able to import from local module', function()
-    local import = require('plenary.import')
-
     local M = {}
     function M.hello() return 'hello' end
 
@@ -21,8 +19,6 @@ describe('import', function()
   end)
 
   it('should be able to import into a local function', function()
-    local import = require('plenary.import')
-
     local M = {}
     function M.hello() return 'hello' end
 
@@ -36,11 +32,22 @@ describe('import', function()
   end)
 
   it('should be able to import with a namespace', function()
-    local import = require('plenary.import')
-
     import { from = "plenary.filetype", as = "ft" }
 
     assert(type(ft) == "table")
     assert(type(ft._get_extension_parts), "function")
+  end)
+
+  it('should be able to import only one thing', function()
+    local M = {}
+    function M.hello() return 'hello' end
+    function M.dont_import() end
+
+    import { "hello", from = M, as = "module"}
+
+    eq(type(hello), 'function')
+    eq(hello(), 'hello')
+    eq(type(dont_import), 'nil')
+    eq(type(module), 'table')
   end)
 end)

--- a/tests/plenary/import_spec.lua
+++ b/tests/plenary/import_spec.lua
@@ -1,0 +1,46 @@
+local eq = assert.are.same
+
+describe('import', function()
+  it('should be able to glob import', function()
+    local import = require('plenary.import')
+
+    import { "*", from = "plenary.filetype" }
+
+    assert(type(_get_extension_parts), "function")
+  end)
+
+  it('should be able to import from local module', function()
+    local import = require('plenary.import')
+
+    local M = {}
+    function M.hello() return 'hello' end
+
+    import { "*", from = M }
+
+    eq(hello(), 'hello')
+  end)
+
+  it('should be able to import into a local function', function()
+    local import = require('plenary.import')
+
+    local M = {}
+    function M.hello() return 'hello' end
+
+    local function test()
+      eq(hello(), 'hello')
+    end
+
+    import { "*", from = M, into = test }
+
+    test()
+  end)
+
+  it('should be able to import with a namespace', function()
+    local import = require('plenary.import')
+
+    import { from = "plenary.filetype", as = "ft" }
+
+    assert(type(ft) == "table")
+    assert(type(ft._get_extension_parts), "function")
+  end)
+end)


### PR DESCRIPTION
Okay, this one is really cool. This pr adds an import dsl that is very clean and has some really cool features. In lua, it is really hard to do glob imports. With the `import` function that this pr comes with, this is really easy. For example, in the upcoming `async` `await` library, there are basically two functions that will always be used, `async` and `await`. It is a pain to always import them manually, and adding them as globals is a bad idea. Now, you can first define a prelude.
```lua
-- example file path plenary/async_prelude
import { from = "plenary.async_lib", as = "a" }
local M = {}
M.async = a.async
M.await = a.await
return M

-- now in another file you can do
import { "*", from = "plenary.async_prelude" }
-- now we can use the async and await functions, they were auto glob imported
async(function ... end)
await(...)
```

Another use case that is really cool. Telescope has an option called `attach_mappings`. The function must take `prompt_bufnr` and `map`. But this is really annoying because I have to take in arguments for the function. `import` can solve this using the `into` option.
```lua
opts = {
  attach_mappings = function()
     local function print_bufnr()
       print(prompt_bufnr) -- using the value as if it has been captured
     end

     map('n', '<leader>p', print_bufnr)  -- use this function as if it has been auto import
  end
}

import { from = {bufnr, map}, into = opts.attach_mappings } -- inject imports into a function
```

There are many more features, check out the tests to see them.