### PR TITLE
fix relative paths with double separators

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -42,6 +42,24 @@ local concat_paths = function(...)
   return table.concat({...}, path.sep)
 end
 
+local function is_root(pathname)
+  if path.sep == '\\' then
+    return string.match(pathname, '^[A-Z]:\\$')
+  end
+  return pathname == '/'
+end
+
+local clean = function(pathname)
+  -- Remove double path seps, it's annoying
+  pathname = pathname:gsub(path.sep .. path.sep, path.sep)
+
+  -- Remove trailing path sep if not root
+  if not is_root(pathname) and pathname:sub(-1) == path.sep then
+    return pathname:sub(1, -2)
+  end
+  return pathname
+end
+
 -- S_IFCHR  = 0o020000  # character device
 -- S_IFBLK  = 0o060000  # block device
 -- S_IFIFO  = 0o010000  # fifo (named pipe)
@@ -213,27 +231,30 @@ function Path:expand()
 end
 
 function Path:make_relative(cwd)
-  cwd = F.if_nil(cwd, self._cwd, cwd)
-  if self.filename:sub(1, #cwd) == cwd  then
-    local offset =  0
-    -- if  cwd does ends in the os separator, we need to take it off
-    if cwd:sub(#cwd, #cwd) ~= path.separator then
-      offset = 1
-    end
+  self.filename = clean(self.filename)
+  cwd = clean(F.if_nil(cwd, self._cwd, cwd))
 
-    self.filename = self.filename:sub(#cwd + 1 + offset, #self.filename)
+  if self.filename:sub(1, #cwd) == cwd then
+    if #self.filename == #cwd then
+      self.filename = "."
+    else
+      -- skip path separator, unless cwd is root
+      local offset = 2
+      if cwd:sub(-1) == path.sep then
+        offset = 1
+      end
+      self.filename = self.filename:sub(#cwd + offset, -1)
+    end
   end
 
   return self.filename
 end
 
 function Path:normalize(cwd)
-  cwd = F.if_nil(cwd, self._cwd, cwd)
   self:make_relative(cwd)
+
   -- Substitute home directory w/ "~"
   self.filename = self.filename:gsub("^" .. path.home, '~', 1)
-  -- Remove double path seps, it's annoying
-  self.filename = self.filename:gsub(path.sep .. path.sep, path.sep)
 
   return self.filename
 end

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -94,16 +94,60 @@ describe('Path', function()
   end)
 
   describe(':make_relative', function()
-    it('can take absoluate paths and make them relative to the cwd', function()
-      local absolute = vim.loop.cwd() .. '/lua/plenary/path.lua'
+    it('can take absolute paths and make them relative to the cwd', function()
+      local p = Path:new { 'lua', 'plenary', 'path.lua' }
+      local absolute = vim.loop.cwd() .. path.sep .. p.filename
       local relative = Path:new(absolute):make_relative()
-      assert.are.same(relative, 'lua/plenary/path.lua')
+      assert.are.same(relative, p.filename)
     end)
 
-    it('can take absoluate paths and make them relative to a given path', function()
-      local absolute = vim.loop.cwd() .. '/lua/plenary/path.lua'
-      local relative = Path:new(absolute):make_relative(vim.loop.cwd() .. '/lua')
-      assert.are.same(relative, 'plenary/path.lua')
+    it('can take absolute paths and make them relative to a given path', function()
+      local root = path.sep == "\\" and "c:\\" or "/"
+      local r = Path:new { root, 'home', 'prime' }
+      local p = Path:new { 'aoeu', 'agen.lua'}
+      local absolute = r.filename .. path.sep .. p.filename
+      local relative = Path:new(absolute):make_relative(r.filename)
+      assert.are.same(relative, p.filename)
+    end)
+
+    it('can take double separator absolute paths and make them relative to the cwd', function()
+      local p = Path:new { 'lua', 'plenary', 'path.lua' }
+      local absolute = vim.loop.cwd() .. path.sep .. path.sep .. p.filename
+      local relative = Path:new(absolute):make_relative()
+      assert.are.same(relative, p.filename)
+    end)
+
+    it('can take double separator absolute paths and make them relative to a given path', function()
+      local root = path.sep == "\\" and "c:\\" or "/"
+      local r = Path:new { root, 'home', 'prime' }
+      local p = Path:new { 'aoeu', 'agen.lua'}
+      local absolute = r.filename .. path.sep .. path.sep .. p.filename
+      local relative = Path:new(absolute):make_relative(r.filename)
+      assert.are.same(relative, p.filename)
+    end)
+
+    it('can take absolute paths and make them relative to a given path with trailing separator', function()
+      local root = path.sep == "\\" and "c:\\" or "/"
+      local r = Path:new { root, 'home', 'prime' }
+      local p = Path:new { 'aoeu', 'agen.lua'}
+      local absolute = r.filename .. path.sep .. p.filename
+      local relative = Path:new(absolute):make_relative(r.filename .. path.sep)
+      assert.are.same(relative, p.filename)
+    end)
+
+    it('can take absolute paths and make them relative to the root directory', function()
+      local root = path.sep == "\\" and "c:\\" or "/"
+      local p = Path:new { 'home', 'prime', 'aoeu', 'agen.lua'}
+      local absolute = root .. p.filename
+      local relative = Path:new(absolute):make_relative(root)
+      assert.are.same(relative, p.filename)
+    end)
+
+    it('can take absolute paths and make them relative to themselves', function()
+      local root = path.sep == "\\" and "c:\\" or "/"
+      local p = Path:new { root, 'home', 'prime', 'aoeu', 'agen.lua'}
+      local relative = Path:new(p.filename):make_relative(p.filename)
+      assert.are.same(relative, ".")
     end)
   end)
 


### PR DESCRIPTION
I had a problem with telescope where if I gave an explicit trailing slash
to a cwd option, the resulting relative path was incorrect if I was in that
same directory, as it would leave an extra slash at the beginning.

I fixed this locally, but when I wanted to make a PR, I noticed there was
a plan to use the path stuff from plenary, so I fixed it in plenary instead
and added some tests that I had.

I'm not sure if I followed the appropriate (lua) coding guidelines as I'm new
to lua, so please review carefully. I also noticed some of the tests seemed
unix specific, and I'm not sure if that was intentional, but in any case I tried
to keep my tests OS-independent.

I used two extra local functions to be able to handle path names as strings
without having to create a Path object (since I could then treat the cwd argument
with the same cleaning function). Here I was also not sure if that is the way
to go.