### PR TITLE
Add `path.root` and make `Path:parents()` return a list of paths

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -33,14 +33,14 @@ path.sep = (function()
 end)()
 
 path.root = (function()
-    if path.sep == '/' then
-        return '/'
-    elseif path.sep == '\\' then
-        local cwd = vim.fn.cwd() -- Get the absolute path of cwd
-        -- Extract the first letter of the path (the drive letter) and
-        -- create the name of the root directory for that drive
-        return cwd[1] .. ':\\'
-    end
+  if path.sep == '/' then
+    return '/'
+  elseif path.sep == '\\' then
+    local cwd = vim.loop.cwd() -- Get the absolute path of cwd
+    -- Extract the first letter of the path (the drive letter) and
+    -- create the name of the root directory for that drive
+    return cwd[1] .. ':\\'
+  end
 end)()
 
 path.S_IF = S_IF
@@ -440,25 +440,25 @@ function Path:_split()
 end
 
 local _get_parent = (function()
-    local formatted = string.format('^(.+)%s[^%s]+', path.sep, path.sep)
-    return function(abs_path)
-        return abs_path:match(formatted)
-    end
+  local formatted = string.format('^(.+)%s[^%s]+', path.sep, path.sep)
+  return function(abs_path)
+    return abs_path:match(formatted)
+  end
 end)()
 
 function Path:parent()
-    return _get_parent(self:absolute()) or path.root
+  return _get_parent(self:absolute()) or path.root
 end
 
 function Path:parents()
-    local results = {}
-    local cur = self:absolute()
-    repeat
-        cur = _get_parent(cur)
-        table.insert(results, cur)
-    until not cur
-    table.insert(results, path.root)
-    return results
+  local results = {}
+  local cur = self:absolute()
+  repeat
+    cur = _get_parent(cur)
+    table.insert(results, cur)
+  until not cur
+  table.insert(results, path.root)
+  return results
 end
 
 function Path:is_file()

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -33,13 +33,13 @@ path.sep = (function()
 end)()
 
 path.root = (function()
-    if path.sep == '/' then return function() return '/' end
-    else
-        return function(base)
-            base = base or vim.loop.cwd()
-            return base:sub(1, 1) .. ':\\'
-        end
+  if path.sep == '/' then return function() return '/' end
+  else
+    return function(base)
+      base = base or vim.loop.cwd()
+      return base:sub(1, 1) .. ':\\'
     end
+  end
 end)()
 
 path.S_IF = S_IF

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -442,7 +442,7 @@ local _get_parent = (function()
 end)()
 
 function Path:parent()
-  return _get_parent(self:absolute()) or path.root
+  return _get_parent(self:absolute()) or path.root(self:absolute())
 end
 
 function Path:parents()

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -36,9 +36,10 @@ path.root = (function()
     if path.sep == '/' then
         return '/'
     elseif path.sep == '\\' then
-        -- This isn't the best way to do this, as the user could be working
-        -- on another drive. Maybe use the output of the :pwd command?
-        return 'C:\\'
+        local cwd = vim.fn.cwd() -- Get the absolute path of cwd
+        -- Extract the first letter of the path (the drive letter) and
+        -- create the name of the root directory for that drive
+        return cwd[1] .. ':\\'
     end
 end)()
 

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -32,12 +32,15 @@ path.sep = (function()
   end
 end)()
 
-path.root = function(base)
-  -- Handle Unix-like paths. The root is always '/'
-  if path.sep == '/' then return '/' end
-  base = base or vim.loop.cwd()
-  return base:sub(1, 1) .. ':\\'
-end
+path.root = (function()
+    if path.sep == '/' then return function() return '/' end
+    else
+        return function(base)
+            base = base or vim.loop.cwd()
+            return base:sub(1, 1) .. ':\\'
+        end
+    end
+end)()
 
 path.S_IF = S_IF
 

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -35,6 +35,7 @@ end)()
 path.root = function(base)
   -- Handle Unix-like paths. The root is always '/'
   if path.sep == '/' then return '/' end
+  base = base or vim.loop.cwd()
   return base:sub(1, 1) .. ':\\'
 end
 

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -447,7 +447,7 @@ local _get_parent = (function()
 end)()
 
 function Path:parent()
-    return _get_parent(self:absolute())
+    return _get_parent(self:absolute()) or path.root
 end
 
 function Path:parents()

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -19,6 +19,24 @@ local S_IF = {
 local path = {}
 path.home = vim.loop.os_homedir()
 
+path.root = (function()
+    if jit then
+        local os = string.lower(jit.os)
+        if os == 'linux' or os == 'osx' or os == 'bsd' then
+            return '/'
+        else
+            return 'C:\\'
+        end
+    else
+        local sep = package.config:sub(1, 1)
+        if sep == '/' then
+            return '/'
+        else
+            return 'C:\\'
+        end
+    end
+end)()
+
 path.sep = (function()
   if jit then
     local os = string.lower(jit.os)
@@ -439,6 +457,7 @@ function Path:parents()
         cur = Path:new(cur:parent())
         table.insert(results, cur.filename)
     until not cur:parent()
+    table.insert(results, path.root)
     return results
 end
 

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -32,16 +32,11 @@ path.sep = (function()
   end
 end)()
 
-path.root = (function()
-  if path.sep == '/' then
-    return '/'
-  elseif path.sep == '\\' then
-    local cwd = vim.loop.cwd() -- Get the absolute path of cwd
-    -- Extract the first letter of the path (the drive letter) and
-    -- create the name of the root directory for that drive
-    return cwd[1] .. ':\\'
-  end
-end)()
+path.root = function(base)
+  -- Handle Unix-like paths. The root is always '/'
+  if path.sep == '/' then return '/' end
+  return base:sub(1, 1) .. ':\\'
+end
 
 path.S_IF = S_IF
 
@@ -457,7 +452,7 @@ function Path:parents()
     cur = _get_parent(cur)
     table.insert(results, cur)
   until not cur
-  table.insert(results, path.root)
+  table.insert(results, path.root(self:absolute()))
   return results
 end
 

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -452,7 +452,7 @@ end
 
 function Path:parents()
     local results = {}
-    local cur = self.filename
+    local cur = self:absolute()
     repeat
         cur = _get_parent(cur)
         table.insert(results, cur)

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -370,7 +370,7 @@ function Path:touch(opts)
   end
 
   if parents then
-    Path:new(self:parents()):mkdir({ parents = true })
+    Path:new(self:parent()):mkdir({ parents = true })
   end
 
   local fd = uv.fs_open(self:_fs_filename(), "w", mode)
@@ -428,8 +428,18 @@ function Path:_split()
   return vim.split(self:absolute(), self._sep)
 end
 
-function Path:parents()
+function Path:parent()
   return self:absolute():match(string.format('^(.+)%s[^%s]+', self._sep, self._sep))
+end
+
+function Path:parents()
+    local results = {}
+    local cur = self
+    repeat
+        cur = Path:new(cur:parent())
+        table.insert(results, cur.filename)
+    until not cur:parent()
+    return results
 end
 
 function Path:is_file()

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -302,7 +302,7 @@ describe('Path', function()
 
   describe('parents', function()
     it('should extract the ancestors of the path', function()
-      local p = Path:new(vim.fn.getcwd())
+      local p = Path:new(vim.loop.cwd())
       local parents = p:parents()
       assert(vim.tbl_islist(parents))
       for _, parent in pairs(parents) do
@@ -310,8 +310,8 @@ describe('Path', function()
       end
     end)
     it('should return itself if it corresponds to path.root', function()
-      local p = Path:new(Path.path.root)
-      assert.are.same(p:parent(), Path.path.root)
+      local p = Path:new(Path.path.root(vim.loop.cwd()))
+      assert.are.same(p:parent(), p.filename)
     end)
   end)
 

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -301,18 +301,18 @@ describe('Path', function()
   end)
 
   describe('parents', function()
-      it('should extract the ancestors of the path', function()
-          local p = Path:new(vim.fn.getcwd())
-          local parents = p:parents()
-          assert(vim.tbl_islist(parents))
-          for _, parent in pairs(parents) do
-              assert.are.same(type(parent), 'string')
-          end
-      end)
-      it('should return itself if it corresponds to path.root', function()
-          local p = Path:new(Path.path.root)
-          assert.are.same(p:parent(), Path.path.root)
-      end)
+    it('should extract the ancestors of the path', function()
+      local p = Path:new(vim.fn.getcwd())
+      local parents = p:parents()
+      assert(vim.tbl_islist(parents))
+      for _, parent in pairs(parents) do
+        assert.are.same(type(parent), 'string')
+      end
+    end)
+    it('should return itself if it corresponds to path.root', function()
+      local p = Path:new(Path.path.root)
+      assert.are.same(p:parent(), Path.path.root)
+    end)
   end)
 
   describe('read parts', function()

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -302,7 +302,7 @@ describe('Path', function()
 
   describe('parents', function()
       it('should extract the ancestors of the path', function()
-          local p = Path:new(vim.fn.cwd())
+          local p = Path:new(vim.fn.getcwd())
           local parents = p:parents()
           assert(vim.tbl_islist(parents))
           for _, parent in pairs(parents) do
@@ -311,7 +311,7 @@ describe('Path', function()
       end)
       it('should return itself if it corresponds to path.root', function()
           local p = Path:new(Path.path.root)
-          assert.are.same(p.parent(), Path.path.root)
+          assert.are.same(p:parent(), Path.path.root)
       end)
   end)
 

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -300,6 +300,21 @@ describe('Path', function()
     end)
   end)
 
+  describe('parents', function()
+      it('should extract the ancestors of the path', function()
+          local p = Path:new(vim.fn.cwd())
+          local parents = p:parents()
+          assert(vim.tbl_islist(parents))
+          for _, parent in pairs(parents) do
+              assert.are.same(type(parent), 'string')
+          end
+      end)
+      it('should return itself if it corresponds to path.root', function()
+          local p = Path:new(Path.path.root)
+          assert.are.same(p.parent(), Path.path.root)
+      end)
+  end)
+
   describe('read parts', function()
     it('should read head of file', function()
       local p = Path:new('LICENSE')


### PR DESCRIPTION
The old `Path:parents()` method was confusing to someone who might have expected that, like in python's pathlib, it return a list of paths, instead of the single path representing the filename of the immediate parent.

The old implementation has been renamed simply to `parent()` and it's usages renamed to reflect that change, and the new implementation returns a list of strings with every ancestor of the original path, including `path.root`
