### PR TITLE
Fixing is_root check for Windows root paths

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -54,7 +54,7 @@ end
 
 local function is_root(pathname)
   if path.sep == '\\' then
-    return string.match(pathname, '^[A-Z]:\\$')
+    return string.match(pathname, '^[A-Z]:\\?$')
   end
   return pathname == '/'
 end


### PR DESCRIPTION
Windows root paths may be `C:\\` or `C:` and the previous regex logic did not capture this