### PR TITLE
fix: make async'd function nil-save

### DIFF
--- a/lua/plenary/async_lib/async.lua
+++ b/lua/plenary/async_lib/async.lua
@@ -2,6 +2,7 @@ local co = coroutine
 local errors = require('plenary.errors')
 local traceback_error = errors.traceback_error
 local f = require('plenary.functional')
+local tbl = require('plenary.tbl')
 
 local M = {}
 
@@ -55,16 +56,19 @@ M.wrap = function(func, argc)
   end
 
   return function(...)
-    local params = {...}
+    local params = tbl.pack(...)
 
     local function future(step)
       if step then
         if type(argc) == "number" then
           params[argc] = step
+          params.n = argc
         else
           table.insert(params, step) -- change once not optional
+          params.n = params.n + 1
         end
-        return func(unpack(params))
+
+        return func(tbl.unpack(params))
       else
         return co.yield(future)
       end
@@ -180,10 +184,10 @@ M.async = function(func)
   end
 
   return function(...)
-    local args = {...}
+    local args = tbl.pack(...)
     local function future(step)
       if step == nil then
-        return func(unpack(args))
+        return func(tbl.unpack(args))
       else
         execute(future, step)
       end

--- a/lua/plenary/tbl.lua
+++ b/lua/plenary/tbl.lua
@@ -16,4 +16,13 @@ function tbl.apply_defaults(original, defaults)
   return original
 end
 
+function tbl.pack(...)
+  return {n=select('#',...); ...}
+end
+
+function tbl.unpack(t, i, j)
+  return unpack(t, i or 1, j or t.n or #t)
+end
+
+
 return tbl


### PR DESCRIPTION
Adapt packing and unpacking of arguments passed through the async wrapper to make sure all arguments are passed down to the function, even if some arguments are `nil`.

I'm not familiar with the project structure, so I just put the helper methods into local module scope. Any place they'd be more at home? Maybe exporting them from `tbl.lua`?

Closes #119 