### PR TITLE
fix: condvar tables resetting

### DIFF
--- a/lua/plenary/async_lib/util.lua
+++ b/lua/plenary/async_lib/util.lua
@@ -84,10 +84,10 @@ end, 2)
 function Condvar:notify_all()
   if #self.handles == 0 then return end
 
-  for _, callback in ipairs(self.handles) do
+  for i, callback in ipairs(self.handles) do
     callback()
+    self.handles[i] = nil
   end
-  self.handles = {} -- reset all handles as they have been used up
 end
 
 ---notify randomly one person that is waiting on this Condvar


### PR DESCRIPTION
Reset callbacks as they go to `nil` and leave table intact instead of creating a new table and resetting the variable that held the previous table.