### PR TITLE
Use vim.v.progpath to spawn busted test runs (fixes stack overflow)

### DIFF
--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -83,7 +83,7 @@ function harness.test_directory(directory, opts)
       end
 
       return Job:new {
-        command = 'nvim',
+        command = vim.v.progpath,
         args = args,
 
         -- Can be turned on to debug


### PR DESCRIPTION
This supports setups where `nvim` is *not* a 0.5 nvim, but where the
test run is started using a different program path, for example using an  alias.

Previously `v --headless [...] -c "PlenaryBustedDirectory [...]"`
failed:

    testing: 	[...]/tests/manual/large_job_spec.lua
    ========================================
    FAILED TO LOAD FILE
    stack overflow
    ========================================

Here `v` is a alias pointing to a development build of neovim with
`$VIMRUNTIME` set appropriately.
