### PR TITLE
Replace f.map with vim.tbl_map

### DIFF
--- a/lua/plenary/functional.lua
+++ b/lua/plenary/functional.lua
@@ -1,14 +1,5 @@
 local f = {}
 
-function f.map(fun, iter)
-  local results = {}
-  for _, v in pairs(iter) do
-    table.insert(results, fun(v))
-  end
-
-  return results
-end
-
 function f.kv_pairs(t)
   local results = {}
   for k, v in pairs(t) do

--- a/lua/plenary/functional.lua
+++ b/lua/plenary/functional.lua
@@ -23,9 +23,9 @@ function f.partial(fun, ...)
   end
 end
 
-function f.any(f, iterable)
+function f.any(fun, iterable)
   for k, v in pairs(iterable) do
-    if f(k, v) then
+    if fun(k, v) then
       return true
     end
   end
@@ -33,9 +33,9 @@ function f.any(f, iterable)
   return false
 end
 
-function f.all(f, iterable)
+function f.all(fun, iterable)
   for k, v in pairs(iterable) do
-    if not f(k, v) then
+    if not fun(k, v) then
       return false
     end
   end

--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -83,7 +83,7 @@ function harness.test_directory(directory, opts)
       end
 
       return Job:new {
-        command = 'nvim',
+        command = vim.v.progpath,
         args = args,
 
         -- Can be turned on to debug

--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -67,7 +67,7 @@ function harness.test_directory(directory, opts)
 
   local path_len = #paths
 
-  local jobs = f.map(
+  local jobs = vim.tbl_map(
     function(p)
       local args = {
         '--headless',
@@ -145,7 +145,7 @@ function harness._find_files_to_run(directory)
     args = {directory, '-type', 'f', '-name', '*_spec.lua'},
   }
 
-  return f.map(Path.new, finder:sync())
+  return vim.tbl_map(Path.new, finder:sync())
 end
 
 function harness._run_path(test_type, directory)


### PR DESCRIPTION
## Avoid shadowing `f` in functional.lua

`fun` is more fun than `f`

## Replace f.map with vim.tbl_map

The implementations are slightly different (`vim.tbl_map` preserves the keys,
and doesn't do an implicit transformation to a list like table)

The `iter` argument name to me also implied that it would take a function
following the lua iterator protocol but that wasn't the case.

Motivation was mostly that I asked myself what's special about `f.map`  while reading some test_harness code

(Not sure if this is okay, as it breaks the API?)