### PR TITLE
Fix quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ nmap <leader>t <Plug>PlenaryTestFile
 To run a whole directory from the command line, you could do something like:
 
 ```
-nvim --headless -c 'PlenaryBustedDirectory tests/plenary/ {minimal_init = "tests/minimal_init.vim"}'
+nvim --headless -c "PlenaryBustedDirectory tests/plenary/ {minimal_init = 'tests/minimal_init.vim'}"
 ```
 
 Where the first argument is the directory you'd like to test. It will search for files with


### PR DESCRIPTION
The example command in the README does not work since it gives the error:
```
Error detected while processing command line:
E5107: Error loading lua [string ":lua"]:1: ')' expected near '.'
Press ENTER or type command to continue
```
Changing the quoting as in this PR fixes the error.