### PR TITLE
Fix normalize path

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -88,7 +88,7 @@ local function _normalize_path(filename)
           idx = idx + 1
       until idx > #parts
 
-      out_file = table.concat(parts, path.sep)
+      out_file = path.sep .. table.concat(parts, path.sep)
   end
 
   return out_file

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -88,7 +88,7 @@ local function _normalize_path(filename)
           idx = idx + 1
       until idx > #parts
 
-      out_file = path.sep .. table.concat(parts, path.sep)
+      out_file = path.root(filename) .. table.concat(parts, path.sep)
   end
 
   return out_file

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -158,22 +158,22 @@ describe('Path', function()
 
   describe(':normalize', function()
     it('can take paths with double separators change them to single separators', function()
-      local orig = 'lua//plenary/path.lua'
+      local orig = '/lua//plenary/path.lua'
       local final = Path:new(orig):normalize()
-      assert.are.same(final, 'lua/plenary/path.lua')
+      assert.are.same(final, '/lua/plenary/path.lua')
     end)
     -- this may be redundant since normalize just calls make_relative which is tested above
     it('can take absolute paths with double seps'
       .. 'and make them relative with single seps', function()
-      local orig = vim.loop.cwd() .. '/lua//plenary/path.lua'
+      local orig = '/lua//plenary/path.lua'
       local final = Path:new(orig):normalize()
-      assert.are.same(final, 'lua/plenary/path.lua')
+      assert.are.same(final, '/lua/plenary/path.lua')
     end)
 
     it('can remove the .. in paths', function()
-      local orig = 'lua//plenary/path.lua/foo/bar/../..'
+      local orig = '/lua//plenary/path.lua/foo/bar/../..'
       local final = Path:new(orig):normalize()
-      assert.are.same(final, 'lua/plenary/path.lua')
+      assert.are.same(final, '/lua/plenary/path.lua')
     end)
   end)
 


### PR DESCRIPTION
think _normalize_path should return absolute path according to absolute()

is that right?

Path:absolute() returns the result of _normalize_path so I would think this change is needed