### PR TITLE
Add nix extension

### DIFF
--- a/data/plenary/filetypes/builtin.lua
+++ b/data/plenary/filetypes/builtin.lua
@@ -31,6 +31,7 @@ return {
     ['jl'] = 'julia',
     ['coffee'] = 'coffee',
     ['_coffee'] = 'coffee',
+    ['nix'] = 'nix',
   },
   file_name = {
     ['cakefile'] = 'coffee',


### PR DESCRIPTION
There is no default [ftplugin](https://github.com/neovim/neovim/tree/master/runtime/ftplugin) for [nix](https://nixos.org/manual/nix/stable/) but with plugins like [vim-nix](https://github.com/LnL7/vim-nix) it is supported and needs to be verbosely added to plenary.