### PR TITLE
Change log location to cache to align with NeoVim.

### DIFF
--- a/lua/plenary/log.lua
+++ b/lua/plenary/log.lua
@@ -51,7 +51,7 @@ local unpack = unpack or table.unpack
 log.new = function(config, standalone)
   config = vim.tbl_deep_extend("force", default_config, config)
 
-  local outfile = string.format('%s/%s.log', vim.api.nvim_call_function('stdpath', {'data'}), config.plugin)
+  local outfile = string.format('%s/%s.log', vim.api.nvim_call_function('stdpath', {'cache'}), config.plugin)
 
   local obj
   if standalone then


### PR DESCRIPTION
Following this in Neovim https://github.com/neovim/neovim/pull/13739 it
probably makes sense to follow suit. I know this may change location for
some that are already using this, but it does seem logical to move this
here since other log files are also being placed here.