### PR TITLE
[WIP] defer futures to run at end of scope

### DIFF
--- a/lua/plenary/functional.lua
+++ b/lua/plenary/functional.lua
@@ -70,6 +70,7 @@ end
 f.first = f.select_only(1)
 f.second = f.select_only(2)
 f.third = f.select_only(3)
+f.fourth = f.select_only(4)
 
 function f.last(...)
   local length = select('#', ...)

--- a/tests/plenary/async_lib/defer_spec.lua
+++ b/tests/plenary/async_lib/defer_spec.lua
@@ -18,12 +18,13 @@ end)
 
 local another_async_func = async(function()
   await(final())
+  a.defer(final())
 end)
 
 local async_func = async(function()
   await(another_async_func())
   a.defer(another_async_func())
-  a.defer(another_async_func())
+  a.defer(final())
 end)
 
 a.run(async_func())

--- a/tests/plenary/async_lib/defer_spec.lua
+++ b/tests/plenary/async_lib/defer_spec.lua
@@ -1,0 +1,29 @@
+require('plenary.async_lib').tests.add_to_env()
+
+-- a.describe('defer', function()
+--   a.it('should run at the end', function()
+--     local counter = 0
+
+--     local should_defer = async(function()
+--       counter = counter + 1
+--     end)
+
+--   end)
+-- end)
+local final_wrap = a.wrap(function(cb) cb() end, 1)
+
+local final = async(function()
+  await(final_wrap())
+end)
+
+local another_async_func = async(function()
+  await(final())
+end)
+
+local async_func = async(function()
+  await(another_async_func())
+  a.defer(another_async_func())
+  a.defer(another_async_func())
+end)
+
+a.run(async_func())

--- a/tests/plenary/async_lib/defer_spec.lua
+++ b/tests/plenary/async_lib/defer_spec.lua
@@ -18,7 +18,7 @@ end)
 
 local another_async_func = async(function()
   await(final())
-  a.defer(final())
+  a.defer(final(), 1)
 end)
 
 local async_func = async(function()


### PR DESCRIPTION
This allows you to defer functions like zig or go. You can specify the level to defer a function from just like `error`.