### PR TITLE
Move type annotation to the Job class definition

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -3,6 +3,20 @@ local uv = vim.loop
 
 local F = require('plenary.functional')
 
+---@class Job
+---@field command string          : Command to run
+---@field args Array              : List of arguments to pass
+---@field cwd string              : Working directory for job
+---@field env Map|Array           : Environment looking like: { ['VAR'] = 'VALUE } or { 'VAR=VALUE' }
+---@field skip_validation boolean : Skip validating the arguments
+---@field enable_handlers boolean : If set to false, disables all callbacks associated with output
+---@field on_start function       : Run when starting job
+---@field on_stdout function      : (error: string, data: string, self? Job)
+---@field on_stderr function      : (error: string, data: string, self? Job)
+---@field on_exit function        : (self, code: number, signal: number)
+---@field maximum_results number  : stop processing results after this number
+---@field writer Job|table|string : Job that writes to stdin of this job.
+---@field enabled_recording boolean
 local Job = {}
 Job.__index = Job
 
@@ -61,22 +75,9 @@ end
 ---@class Map
 --- Map-like table
 
---- Create a new job
----
----@class Job
----@class o
----@field command string          : Command to run
----@field args Array              : List of arguments to pass
----@field cwd string              : Working directory for job
----@field env Map|Array           : Environment looking like: { ['VAR'] = 'VALUE } or { 'VAR=VALUE' }
----@field skip_validation boolean : Skip validating the arguments
----@field enable_handlers boolean : If set to false, disables all callbacks associated with output
----@field on_start function       : Run when starting job
----@field on_stdout function      : (error: string, data: string, self? Job)
----@field on_stderr function      : (error: string, data: string, self? Job)
----@field on_exit function        : (self, code: number, signal: number)
----@field maximum_results number  : stop processing results after this number
----@field writer Job|table|string : Job that writes to stdin of this job.
+---Create a new job
+---@param o Job
+---@return Job
 function Job:new(o)
   if not o then
     error(debug.traceback("Options are required for Job:new"))


### PR DESCRIPTION
Whilst developing a plugin using plenary's job module I added plenary to my `sumneko_lua` workspace library using
```lua
settings = {
  Lua = {
    workspace = {
       library = {
         [path_to_plenary] = true
       }
    }
  }
```
I find the type annotations very helpful in my project since I can import the type via
```lua
---@type Job
local Job = require('plenary.job')
```
Unfortunately the type annotations seem to be misplaced i.e. the `new` function is annotated rather than the actual class object that is exported. This means that the exported types has none of the correct methods. By moving the annotation to the declaration of `Job` this is now recognised correctly.

NOTE: the `new` function is just a function so annotating it doesn't apply the types to the object it returns given the object itself isn't typed