### PR TITLE
Add fish to filetypes shebangs table

### DIFF
--- a/data/plenary/filetypes/builtin.lua
+++ b/data/plenary/filetypes/builtin.lua
@@ -3,6 +3,7 @@ local shebang_fts = {
   ['sh'] = 'sh',
   ['bash'] = 'sh',
   ['zsh'] = 'zsh',
+  ['fish'] = 'fish',
   ['python'] = 'python',
   ['python2'] = 'python',
   ['python3'] = 'python',


### PR DESCRIPTION
I am aware of https://github.com/nvim-lua/plenary.nvim#plenaryfiletype and I added fish as a extension manually. However, if I were to add the shebang manually I would also have to add more than one line because of all the prefixes.😁