### PR TITLE
Add eruby filetype

### DIFF
--- a/data/plenary/filetypes/builtin.lua
+++ b/data/plenary/filetypes/builtin.lua
@@ -32,6 +32,7 @@ return {
     ['coffee'] = 'coffee',
     ['_coffee'] = 'coffee',
     ['nix'] = 'nix',
+    ['erb'] = 'eruby',
   },
   file_name = {
     ['cakefile'] = 'coffee',


### PR DESCRIPTION
I just started using telescope and noticed that eruby doesn't have syntax highlighting in preview. This change fixes that.