### PR TITLE
Fix `path.shorten` returning `nil`

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -341,7 +341,7 @@ local shorten = (function()
     end
   end
   return function(filename)
-    shorten_len(filename, 1)
+    return shorten_len(filename, 1)
   end
 end)()
 


### PR DESCRIPTION
Fixes current situation where `path.shorten` function may not return anything