### PR TITLE
fix: apply respect_gitignore to directories

### DIFF
--- a/lua/plenary/scandir.lua
+++ b/lua/plenary/scandir.lua
@@ -80,9 +80,11 @@ local process_item = function(opts, name, typ, current_dir, next_dir, bp, data, 
         table.insert(next_dir, entry)
       end
       if opts.add_dirs then
-        if not msp or msp(entry) then
-          table.insert(data, entry)
-          if opts.on_insert then opts.on_insert(entry, typ) end
+        if not giti or interpret_gitignore(giti, bp, entry .. "/") then
+          if not msp or msp(entry) then
+            table.insert(data, entry)
+            if opts.on_insert then opts.on_insert(entry, typ) end
+          end
         end
       end
     else


### PR DESCRIPTION
Currently, directories are always added to `scan_dir` results when `add_dirs = true`. This PR makes `respect_gitignore` behavior consistent for files and directories. 

It also appends `/` to the entry to handle gitignore directory patterns. This makes it so that that the gitignore patterns `/node_modules`, `node_modules`, and `node_modules/` (all of which, according to [the documentation](https://git-scm.com/docs/gitignore), are valid, with slightly different interpretations) will all correctly match the entry `/path/to/node_modules`. 

(I wanted to add a test but wasn't sure how to do so without modifying the project's `.gitignore` file, which seemed like a bad idea, so let me know.)