### PR TITLE
[BLOCKER] Fixed raw body passing for the cURL wrapper

### DIFF
--- a/lua/plenary/curl.lua
+++ b/lua/plenary/curl.lua
@@ -154,7 +154,7 @@ parse.request = function(opts)
     elseif P.is_file(P.new(b)) then
       opts.in_file = b
     elseif type(b) == "string" then
-      opts.raw = b
+      opts.raw_body = b
     end
   end
   return vim.tbl_flatten({
@@ -163,7 +163,7 @@ parse.request = function(opts)
     parse.method(opts.method),
     parse.headers(opts.headers),
     parse.accept_header(opts.accept),
-    parse.raw_body(opts.raw),
+    parse.raw_body(opts.raw_body),
     parse.data_body(opts.data),
     parse.form(opts.form),
     parse.file(opts.in_file),

--- a/tests/plenary/curl_spec.lua
+++ b/tests/plenary/curl_spec.lua
@@ -151,6 +151,22 @@ describe('CURL Wrapper:', function()
       eq(json, vim.fn.json_decode(res).json)
     end)
 
+
+    it("should not include the body twice", function ()
+      local json = { title = "New", name = "YORK" }
+      local body = vim.fn.json_encode(json)
+      local res = curl.post("https://postman-echo.com/post", {
+        body = body,
+        headers = {
+          content_type = "application/json"
+        },
+        dry_run = true,
+      })
+      local joined_response = table.concat(res, " ")
+      local first_index = joined_response:find(body)
+
+      eq(nil, joined_response:find(body, first_index + 1))
+    end)
   end)
   describe("PUT", function() --------------------------------------------------
 


### PR DESCRIPTION
Hey all!

at first: let me thank you for this awesome library!

I found a bug while trying to pass a string as body to the cURL wrapper.

As we can see in [this line](https://github.com/nvim-lua/plenary.nvim/blame/22127c47454e3b09be38b3a4bbe3edf42e7b3fc7/lua/plenary/curl.lua#L142) the argument for passing extra command line arguments to curl was named `raw_args` and [the option](https://github.com/nvim-lua/plenary.nvim/blame/22127c47454e3b09be38b3a4bbe3edf42e7b3fc7/lua/plenary/curl.lua#L137) for setting the raw body was named `raw`.

As we can see in [this commit](https://github.com/nvim-lua/plenary.nvim/blob/08c0eabcb1/lua/plenary/curl.lua#L171) by @tami5 it changed. The name for the option for passing extra arguments to cURL was renamed to `raw`!

Source: https://github.com/nvim-lua/plenary.nvim/commit/08c0eabcb1fdcc5b72f60c3a328ae8eeb7ad374e#diff-ee99434c11a1e82e1ffd7308db38479b4648e17027be731e1ef592a055df0c89R171

For backwards compatibility I renamed the internal option name to `raw_body` and adjusted the call to the `parse.raw_body` function.