### PR TITLE
feat: added json_strip_comments

### DIFF
--- a/lua/plenary/json.lua
+++ b/lua/plenary/json.lua
@@ -1,0 +1,102 @@
+-- based on https://github.com/sindresorhus/strip-json-comments
+
+local singleComment = "singleComment"
+local multiComment = "multiComment"
+local stripWithoutWhitespace = function()
+  return ""
+end
+
+local function slice(str, from, to)
+  from = from or 1
+  to = to or #str
+  return str:sub(from, to)
+end
+
+local stripWithWhitespace = function(str, from, to)
+  return slice(str, from, to):gsub("%S", " ")
+end
+
+local isEscaped = function(jsonString, quotePosition)
+  local index = quotePosition - 1
+  local backslashCount = 0
+
+  while jsonString:sub(index, index) == "\\" do
+    index = index - 1
+    backslashCount = backslashCount + 1
+  end
+  return backslashCount % 2 == 1 and true or false
+end
+
+local M = {}
+
+-- Strips any json comments from a json string.
+-- The resulting string can then be used by `vim.fn.json_decode`
+--
+---@param jsonString string
+---@param options table
+---  * whitespace:
+---     - defaults to true
+---     - when true, comments will be replaced by whitespace
+---     - when false, comments will be stripped
+function M.json_strip_comments(jsonString, options)
+  options = options or {}
+  local strip = options.whitespace == false and stripWithoutWhitespace or stripWithWhitespace
+
+  local insideString = false
+  local insideComment = false
+  local offset = 1
+  local result = ""
+  local skip = false
+
+  for i = 1, #jsonString, 1 do
+    if skip then
+      skip = false
+    else
+      local currentCharacter = jsonString:sub(i, i)
+      local nextCharacter = jsonString:sub(i + 1, i + 1)
+
+      if not insideComment and currentCharacter == '"' then
+        local escaped = isEscaped(jsonString, i)
+        if not escaped then
+          insideString = not insideString
+        end
+      end
+
+      if not insideString then
+        if not insideComment and currentCharacter .. nextCharacter == "//" then
+          result = result .. slice(jsonString, offset, i - 1)
+          offset = i
+          insideComment = singleComment
+          i = i + 1
+          skip = true
+        elseif insideComment == singleComment and currentCharacter .. nextCharacter == "\r\n" then
+          i = i + 1
+          skip = true
+          insideComment = false
+          result = result .. strip(jsonString, offset, i - 1)
+          offset = i
+        elseif insideComment == singleComment and currentCharacter == "\n" then
+          insideComment = false
+          result = result .. strip(jsonString, offset, i - 1)
+          offset = i
+        elseif not insideComment and currentCharacter .. nextCharacter == "/*" then
+          result = result .. slice(jsonString, offset, i - 1)
+          offset = i
+          insideComment = multiComment
+          i = i + 1
+          skip = true
+        elseif insideComment == multiComment and currentCharacter .. nextCharacter == "*/" then
+          i = i + 1
+          skip = true
+          insideComment = false
+          result = result .. strip(jsonString, offset, i)
+          offset = i + 1
+        end
+      end
+    end
+  end
+
+  return result .. (insideComment and strip(slice(jsonString, offset)) or slice(jsonString, offset))
+end
+
+return M

--- a/tests/plenary/json_spec.lua
+++ b/tests/plenary/json_spec.lua
@@ -1,0 +1,70 @@
+local json = require("plenary.json")
+local eq = assert.are.same
+
+describe("json", function()
+  it("replace comments with whitespace", function()
+    eq(json.json_strip_comments('//comment\n{"a":"b"}'), '         \n{"a":"b"}')
+    eq(json.json_strip_comments('/*//comment*/{"a":"b"}'), '             {"a":"b"}')
+    eq(json.json_strip_comments('{"a":"b"//comment\n}'), '{"a":"b"         \n}')
+    eq(json.json_strip_comments('{"a":"b"/*comment*/}'), '{"a":"b"           }')
+    eq(json.json_strip_comments('{"a"/*\n\n\ncomment\r\n*/:"b"}'), '{"a"  \n\n\n       \r\n  :"b"}')
+    eq(json.json_strip_comments('/*!\n * comment\n */\n{"a":"b"}'), '   \n          \n   \n{"a":"b"}')
+    eq(json.json_strip_comments('{/*comment*/"a":"b"}'), '{           "a":"b"}')
+  end)
+
+  it("remove comments", function()
+    local options = { whitespace = false }
+    eq(json.json_strip_comments('//comment\n{"a":"b"}', options), '\n{"a":"b"}')
+    eq(json.json_strip_comments('/*//comment*/{"a":"b"}', options), '{"a":"b"}')
+    eq(json.json_strip_comments('{"a":"b"//comment\n}', options), '{"a":"b"\n}')
+    eq(json.json_strip_comments('{"a":"b"/*comment*/}', options), '{"a":"b"}')
+    eq(json.json_strip_comments('{"a"/*\n\n\ncomment\r\n*/:"b"}', options), '{"a":"b"}')
+    eq(json.json_strip_comments('/*!\n * comment\n */\n{"a":"b"}', options), '\n{"a":"b"}')
+    eq(json.json_strip_comments('{/*comment*/"a":"b"}', options), '{"a":"b"}')
+  end)
+
+  it("doesn't strip comments inside strings", function()
+    eq(json.json_strip_comments('{"a":"b//c"}'), '{"a":"b//c"}')
+    eq(json.json_strip_comments('{"a":"b/*c*/"}'), '{"a":"b/*c*/"}')
+    eq(json.json_strip_comments('{"/*a":"b"}'), '{"/*a":"b"}')
+    eq(json.json_strip_comments('{"\\"/*a":"b"}'), '{"\\"/*a":"b"}')
+  end)
+
+  it("consider escaped slashes when checking for escaped string quote", function()
+    eq(json.json_strip_comments('{"\\\\":"https://foobar.com"}'), '{"\\\\":"https://foobar.com"}')
+    eq(json.json_strip_comments('{"foo\\"":"https://foobar.com"}'), '{"foo\\"":"https://foobar.com"}')
+  end)
+
+  it("line endings - no comments", function()
+    eq(json.json_strip_comments('{"a":"b"\n}'), '{"a":"b"\n}')
+    eq(json.json_strip_comments('{"a":"b"\r\n}'), '{"a":"b"\r\n}')
+  end)
+
+  it("line endings - single line comment", function()
+    eq(json.json_strip_comments('{"a":"b"//c\n}'), '{"a":"b"   \n}')
+    eq(json.json_strip_comments('{"a":"b"//c\r\n}'), '{"a":"b"   \r\n}')
+  end)
+
+  it("line endings - single line block comment", function()
+    eq(json.json_strip_comments('{"a":"b"/*c*/\n}'), '{"a":"b"     \n}')
+    eq(json.json_strip_comments('{"a":"b"/*c*/\r\n}'), '{"a":"b"     \r\n}')
+  end)
+
+  it("line endings - multi line block comment", function()
+    eq(json.json_strip_comments('{"a":"b",/*c\nc2*/"x":"y"\n}'), '{"a":"b",   \n    "x":"y"\n}')
+    eq(json.json_strip_comments('{"a":"b",/*c\r\nc2*/"x":"y"\r\n}'), '{"a":"b",   \r\n    "x":"y"\r\n}')
+  end)
+
+  it("line endings - works at EOF", function()
+    local options = { whitespace = false }
+    eq(json.json_strip_comments('{\r\n\t"a":"b"\r\n} //EOF'), '{\r\n\t"a":"b"\r\n}      ')
+    eq(json.json_strip_comments('{\r\n\t"a":"b"\r\n} //EOF', options), '{\r\n\t"a":"b"\r\n} ')
+  end)
+
+  it("handles weird escaping", function()
+    eq(
+      json.json_strip_comments([[{"x":"x \"sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""}]]),
+      [[{"x":"x \"sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""}]]
+    )
+  end)
+end)


### PR DESCRIPTION
this PR adds an utility method to strip comments from json strings so the resulting string can be loaded with `vim.fn.json_decode`.

JSONC is used by vscode and others to allow having comments inside JSON files.

The PR is a Lua port of [strip-json-comments](https://github.com/sindresorhus/strip-json-comments)

All the test cases have also been ported.

## Usage

```lua
local json = require("plenary.json")

local str = [[
{
  // this is a comment
  "a": 123, // foo
  /* a multi
  line
  comment
  */ "b": 222
}
]]

local stripped = json.json_strip_comments(str)
local obj = vim.fn.json_decode(stripped)

print(vim.inspect(obj))
```

This will print:

```lua
{                                                                                                                                                                                                                                                                                        
  a = 123,                                                                                                                                                                                                                                                                               
  b = 222                                                                                                                                                                                                                                                                                
}   
```