### PR TITLE
feat(job): add tests for missing ending newline in command output

### DIFF
--- a/tests/plenary/job_spec.lua
+++ b/tests/plenary/job_spec.lua
@@ -91,6 +91,42 @@ describe("Job", function()
       assert.are.same(job:result(), { "hello", "world" })
       assert.are.same(job:result(), results)
     end)
+
+    it('should return last line when there is ending newline', function()
+      local results = {}
+      local job = Job:new {
+        command = 'echo',
+
+        args = { "-e", "test1\ntest2" },
+
+        on_stdout = function(_, data)
+          table.insert(results, data)
+        end,
+      }
+
+      job:sync()
+
+      assert.are.same(job:result(), {'test1', 'test2'})
+      assert.are.same(job:result(), results)
+    end)
+
+    it('should return last line when there is no ending newline', function()
+      local results = {}
+      local job = Job:new {
+        command = 'echo',
+
+        args = { "-en", "test1\ntest2" },
+
+        on_stdout = function(_, data)
+          table.insert(results, data)
+        end,
+      }
+
+      job:sync()
+
+      assert.are.same(job:result(), {'test1', 'test2'})
+      assert.are.same(job:result(), results)
+    end)
   end)
 
   describe("env", function()


### PR DESCRIPTION
Add tests for the situation where the command output does not have
an ending newline. The first test shows what happens when the newline is
output, the second test shows what happend when the newline is not
there.