### PR TITLE
fix(path): remove duplicate function definition

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -500,10 +500,6 @@ function Path:is_dir()
   return band(S_IF.DIR, self:_st_mode())
 end
 
-function Path:is_file()
-  return band(S_IF.REG, self:_st_mode())
-end
-
 function Path:is_absolute()
   if self._sep == '\\' then
     return string.match(self.filename, '^[A-Z]:\\.*$')


### PR DESCRIPTION
We have two `Path:is_file()` methods defined:

1. https://github.com/nvim-lua/plenary.nvim/blob/8bae2c1fadc9ed5bfcfb5ecbd0c0c4d7d40cb974/lua/plenary/path.lua#L503-L505
2. https://github.com/nvim-lua/plenary.nvim/blob/8bae2c1fadc9ed5bfcfb5ecbd0c0c4d7d40cb974/lua/plenary/path.lua#L541-L546

Any reasons to keep both?