### PR TITLE
Make Path:is_root() public

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -50,9 +50,10 @@ local concat_paths = function(...)
   return table.concat({...}, path.sep)
 end
 
-local function is_root(pathname)
-  if path.sep == '\\' then
-    return string.match(pathname, '^[A-Z]:\\?$')
+local function is_root(pathname, sep)
+  sep = sep or path.sep
+  if sep == '\\' then
+    return string.match(pathname, '^[A-Z]:\\?$') ~= nil
   end
   return pathname == '/'
 end
@@ -299,6 +300,10 @@ function Path:normalize(cwd)
   self.filename = self.filename:gsub("^" .. path.home, '~', 1)
 
   return _normalize_path(self.filename)
+end
+
+function Path:is_root()
+  return is_root(self.filename, self._sep)
 end
 
 local function shorten_len(filename, len)

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -191,6 +191,18 @@ describe('Path', function()
     end)
   end)
 
+  describe(':is_root', function()
+    it('can detect the root path on UNIX-like systems', function()
+      local p = Path:new{'/', sep = '/'}
+      assert.is_true(p:is_root())
+    end)
+
+    it('can detect the root path on Windows', function()
+      local p = Path:new{'C:\\', sep = '\\'}
+      assert.is_true(p:is_root())
+    end)
+  end)
+
   describe(':shorten', function()
     it('can shorten a path', function()
       local long_path = '/this/is/a/long/path'


### PR DESCRIPTION
I want to use this func from other modules.

See https://github.com/nvim-telescope/telescope-z.nvim/blob/f5776dbd0c687af0862b2e4ee83c62c5f4a7271d/lua/telescope/_extensions/z_builtin.lua#L16-L23