### PR TITLE
Make Path:parent() return a Path object instead of a string

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -524,7 +524,7 @@ local _get_parent = (function()
 end)()
 
 function Path:parent()
-  return _get_parent(self:absolute()) or path.root(self:absolute())
+  return Path:new(_get_parent(self:absolute()) or path.root(self:absolute()))
 end
 
 function Path:parents()

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -410,7 +410,7 @@ describe('Path', function()
     end)
     it('should return itself if it corresponds to path.root', function()
       local p = Path:new(Path.path.root(vim.loop.cwd()))
-      assert.are.same(p:parent(), p.filename)
+      assert.are.same(p:parent(), p)
     end)
   end)
 


### PR DESCRIPTION
Closes #193 