### PR TITLE
removed unnecessary debug print() in path.lua

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -142,7 +142,6 @@ end
 
 -- TODO: See where we concat the table, and maybe we could make this work.
 Path.__concat = function(self, other)
-  print(self, other)
   return self.filename .. other
 end
 


### PR DESCRIPTION
This PR gets rid of an unnecessary print statements which is annoying if you want to do something like `tostring(path)`

It's needed for a big fix PR of telescope-project 

 https://github.com/nvim-telescope/telescope-project.nvim/issues/58#issuecomment-890568732