### PR TITLE
fix: default to noautocmd for popup like vim

### DIFF
--- a/POPUP.md
+++ b/POPUP.md
@@ -10,7 +10,7 @@ stablization and any required features are merged into Neovim, we can upstream
 this and expose the API in vimL to create better compatibility.
 
 ## Notices
-- **2021-08-13:** we now follow Vim's default to `noautocmd` on popup creation. This can be overriden with `vim_options.noautocmd=false`
+- **2021-08-19:** we now follow Vim's default to `noautocmd` on popup creation. This can be overriden with `vim_options.noautocmd=false`
 
 ## List of Neovim Features Required:
 

--- a/POPUP.md
+++ b/POPUP.md
@@ -9,6 +9,9 @@ Provide an API that is compatible with the vim `popup_*` APIs. After
 stablization and any required features are merged into Neovim, we can upstream
 this and expose the API in vimL to create better compatibility.
 
+## Notices
+- **2021-08-13:** we now follow Vim's default to `noautocmd` on popup creation. This can be overriden with `vim_options.noautocmd=false`
+
 ## List of Neovim Features Required:
 
 - [ ] Add Z-index for floating windows

--- a/lua/plenary/popup/init.lua
+++ b/lua/plenary/popup/init.lua
@@ -198,6 +198,9 @@ function popup.create(what, vim_options)
   --   textpropwin
   --   textpropid
 
+  -- noautocmd, undocumented vim default per https://github.com/vim/vim/issues/5737
+  win_opts.noautocmd = vim.F.if_nil(vim_options.noautocmd, true)
+
   local win_id
   if vim_options.hidden then
     assert(false, "I have not implemented this yet and don't know how")
@@ -358,7 +361,11 @@ function popup.create(what, vim_options)
   if should_enter then
     -- set focus after border creation so that it's properly placed (especially
     -- in relative cursor layout)
-    vim.api.nvim_set_current_win(win_id)
+    if vim_options.noautocmd then
+      vim.cmd("noautocmd lua vim.api.nvim_set_current_win(" .. win_id .. ")")
+    else
+      vim.api.nvim_set_current_win(win_id)
+    end
   end
 
   -- callback

--- a/lua/plenary/popup/init.lua
+++ b/lua/plenary/popup/init.lua
@@ -244,7 +244,12 @@ function popup.create(what, vim_options)
   end
 
   if vim_options.wrap ~= nil then
-    vim.api.nvim_win_set_option(win_id, "wrap", vim_options.wrap)
+    -- set_option wrap should/will trigger autocmd, see https://github.com/neovim/neovim/pull/13247
+    if vim_options.noautocmd then
+      vim.cmd(string.format("noautocmd lua vim.api.nvim_set_option(%s, wrap, %s)", win_id, vim_options.wrap))
+    else
+      vim.api.nvim_win_set_option(win_id, "wrap", vim_options.wrap)
+    end
   end
 
   -- ===== Not Implemented Options =====

--- a/lua/plenary/window/border.lua
+++ b/lua/plenary/window/border.lua
@@ -144,6 +144,7 @@ function Border:new(content_bufnr, content_win_id, content_win_options, border_w
     col = content_win_options.col - thickness.left,
     width = content_win_options.width + thickness.left + thickness.right,
     height = content_win_options.height + thickness.top + thickness.bot,
+    noautocmd = content_win_options.noautocmd,
   })
 
   vim.cmd(


### PR DESCRIPTION
As per this [vim issue](https://github.com/vim/vim/issues/5737) `noautocmd` is the default for popups (couldn't find it in docs), which now is configurable via `vim_options.noautocmd`.

cc @l-kershaw 
