### PR TITLE
feat: popup and border zindex

### DIFF
--- a/POPUP.md
+++ b/POPUP.md
@@ -11,8 +11,6 @@ this and expose the API in vimL to create better compatibility.
 
 ## List of Neovim Features Required:
 
-- [ ] Add Z-index for floating windows
-    - [ ] When complete, we can add `zindex` parameter
 - [ ] Key handlers (used for `popup_filter`)
 - [ ] scrollbar for floating windows
     - [ ] scrollbar
@@ -66,6 +64,7 @@ Suported Features:
     - [x] time
     - [x] title
     - [x] wrap
+    - [x] zindex
 
 ## All known unimplemented vim features at the moment
 

--- a/lua/plenary/popup/init.lua
+++ b/lua/plenary/popup/init.lua
@@ -92,6 +92,7 @@ function popup.create(what, vim_options)
 
   local option_defaults = {
     posinvert = true,
+    zindex = 50,
   }
 
   local win_opts = {}
@@ -197,6 +198,11 @@ function popup.create(what, vim_options)
   -- related:
   --   textpropwin
   --   textpropid
+
+  -- zindex, Priority for the popup, default 50.  Minimum value is
+  -- ,   1, maximum value is 32000.
+  local zindex = dict_default(vim_options, "zindex", option_defaults)
+  win_opts.zindex = utils.bounded(zindex, 1, 32000)
 
   local win_id
   if vim_options.hidden then

--- a/lua/plenary/window/border.lua
+++ b/lua/plenary/window/border.lua
@@ -144,6 +144,7 @@ function Border:new(content_bufnr, content_win_id, content_win_options, border_w
     col = content_win_options.col - thickness.left,
     width = content_win_options.width + thickness.left + thickness.right,
     height = content_win_options.height + thickness.top + thickness.bot,
+    zindex = content_win_options.zindex or 50,
   })
 
   vim.cmd(


### PR DESCRIPTION
This is an updated version of [this](https://github.com/nvim-lua/popup.nvim/pull/17).

I was expecting to need to subtract 1 when setting the border zindex, but it _seems_ to work fine being set the same.

![image](https://user-images.githubusercontent.com/35707277/129607800-7af8eac3-82b9-4c17-932f-0f2939c2bb58.png)
