### PR TITLE
feat: add options for popup being focusable

### DIFF
--- a/lua/plenary/popup/init.lua
+++ b/lua/plenary/popup/init.lua
@@ -201,6 +201,10 @@ function popup.create(what, vim_options)
   -- noautocmd, undocumented vim default per https://github.com/vim/vim/issues/5737
   win_opts.noautocmd = vim.F.if_nil(vim_options.noautocmd, true)
 
+  -- focusable,
+  -- vim popups are not focusable windows
+  win_opts.focusable = vim.F.if_nil(vim_options.focusable, false)
+
   local win_id
   if vim_options.hidden then
     assert(false, "I have not implemented this yet and don't know how")
@@ -346,6 +350,7 @@ function popup.create(what, vim_options)
 
   local border = nil
   if should_show_border then
+    border_options.focusable = vim_options.border_focusable
     border = Border:new(bufnr, win_id, win_opts, border_options)
   end
 

--- a/lua/plenary/window/border.lua
+++ b/lua/plenary/window/border.lua
@@ -189,6 +189,7 @@ function Border:new(content_bufnr, content_win_id, content_win_options, border_w
     width = content_win_options.width + thickness.left + thickness.right,
     height = content_win_options.height + thickness.top + thickness.bot,
     noautocmd = content_win_options.noautocmd,
+    focusable = vim.F.if_nil(border_win_options.focusable, false),
   })
 
   vim.cmd(


### PR DESCRIPTION
Adds options `focusable` and `border_focusable` in `popup` (and `focusable` in `Border`) to change whether user window actions can focus the content window and popup window.
To match popup behaviour from vim, the defaults for both are false, which may break some plugin use cases (doesn't seem to break Telescope in my quick tests, but we should still specify the behaviour we want over there).