### PR TITLE
fix(job): Don't kill coroutine if there is still data

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -354,7 +354,7 @@ local on_output = function(self, result_key, cb)
         cb(err, result_line, self)
       end
 
-      if data == nil or is_complete then
+      if (data == nil and not result_line) or is_complete then
         return
       end
 


### PR DESCRIPTION
If a command doesn't issue a newline in its final line, it is possible
for this line not to be passed to the users on_stdout callback.
