### PR TITLE
feat: allow `pos="center"`, `row=0`, `line=0`

### DIFF
--- a/POPUP.md
+++ b/POPUP.md
@@ -10,7 +10,7 @@ stablization and any required features are merged into Neovim, we can upstream
 this and expose the API in vimL to create better compatibility.
 
 ## Notices
-- **2021-09-05:** we now follow Vim's convention of the first line/column of the screen being indexed 1, so that 0 can be used for centering.
+- **2021-09-19:** we now follow Vim's convention of the first line/column of the screen being indexed 1, so that 0 can be used for centering.
 - **2021-08-19:** we now follow Vim's default to `noautocmd` on popup creation. This can be overriden with `vim_options.noautocmd=false`
 
 ## List of Neovim Features Required:

--- a/POPUP.md
+++ b/POPUP.md
@@ -10,6 +10,7 @@ stablization and any required features are merged into Neovim, we can upstream
 this and expose the API in vimL to create better compatibility.
 
 ## Notices
+- **2021-09-05:** we now follow Vim's convention of the first line/column of the screen being indexed 1, so that 0 can be used for centering.
 - **2021-08-19:** we now follow Vim's default to `noautocmd` on popup creation. This can be overriden with `vim_options.noautocmd=false`
 
 ## List of Neovim Features Required:

--- a/lua/plenary/popup/init.lua
+++ b/lua/plenary/popup/init.lua
@@ -146,7 +146,7 @@ function popup.create(what, vim_options)
     if type(vim_options.line) == "string" then
       win_opts.row = cursor_relative_pos(vim_options.line, "row")
     else
-      win_opts.row = vim_options.line
+      win_opts.row = vim_options.line - 1
     end
   else
     win_opts.row = math.floor((vim.o.lines - win_opts.height)/2)
@@ -156,7 +156,7 @@ function popup.create(what, vim_options)
     if type(vim_options.col) == "string" then
       win_opts.col = cursor_relative_pos(vim_options.col, "col")
     else
-      win_opts.col = vim_options.col
+      win_opts.col = vim_options.col - 1
     end
   else
     win_opts.col = math.floor((vim.o.columns - win_opts.width)/2)

--- a/lua/plenary/popup/init.lua
+++ b/lua/plenary/popup/init.lua
@@ -117,7 +117,12 @@ function popup.create(what, vim_options)
   win_opts.width = utils.bounded(width, vim_options.minwidth, vim_options.maxwidth)
   win_opts.height = utils.bounded(height, vim_options.minheight, vim_options.maxheight)
 
-  -- 
+  -- pos
+  --
+  -- Using "topleft", "topright", "botleft", "botright" defines what corner of the popup "line"
+  -- and "col" are used for. When not set "topleft" behaviour is used.
+  -- Alternatively "center" can be used to position the popup in the center of the Neovim window,
+  -- in which case "line" and "col" are ignored.
   if vim_options.pos then
     if vim_options.pos == "center" then
       vim_options.line = 0
@@ -149,7 +154,7 @@ function popup.create(what, vim_options)
       win_opts.row = vim_options.line - 1
     end
   else
-    win_opts.row = math.floor((vim.o.lines - win_opts.height)/2)
+    win_opts.row = math.floor((vim.o.lines - win_opts.height) / 2)
   end
 
   if vim_options.col and vim_options.col ~= 0 then
@@ -159,7 +164,7 @@ function popup.create(what, vim_options)
       win_opts.col = vim_options.col - 1
     end
   else
-    win_opts.col = math.floor((vim.o.columns - win_opts.width)/2)
+    win_opts.col = math.floor((vim.o.columns - win_opts.width) / 2)
   end
 
   -- , fixed    When FALSE (the default), and:

--- a/lua/plenary/popup/init.lua
+++ b/lua/plenary/popup/init.lua
@@ -98,61 +98,6 @@ function popup.create(what, vim_options)
   local win_opts = {}
   win_opts.relative = "editor"
 
-  local cursor_relative_pos = function(pos_str, dim)
-    assert(string.find(pos_str, "^cursor"), "Invalid value for " .. dim)
-    win_opts.relative = "cursor"
-    local line = 0
-    if (pos_str):match "cursor%+(%d+)" then
-      line = line + tonumber((pos_str):match "cursor%+(%d+)")
-    elseif (pos_str):match "cursor%-(%d+)" then
-      line = line - tonumber((pos_str):match "cursor%-(%d+)")
-    end
-    return line
-  end
-
-  if vim_options.line then
-    if type(vim_options.line) == "string" then
-      win_opts.row = cursor_relative_pos(vim_options.line, "row")
-    else
-      win_opts.row = vim_options.line
-    end
-  else
-    -- TODO: It says it needs to be "vertically cenetered"?...
-    -- wut is that.
-    win_opts.row = 0
-  end
-
-  if vim_options.col then
-    if type(vim_options.col) == "string" then
-      win_opts.col = cursor_relative_pos(vim_options.col, "col")
-    else
-      win_opts.col = vim_options.col
-    end
-  else
-    -- TODO: It says it needs to be "horizontally cenetered"?...
-    win_opts.col = 0
-  end
-
-  if vim_options.pos then
-    if vim_options.pos == "center" then
-      -- TODO: Do centering..
-    else
-      win_opts.anchor = popup._pos_map[vim_options.pos]
-    end
-  else
-    win_opts.anchor = "NW" -- This is the default, but makes `posinvert` easier to implement
-  end
-
-  -- , fixed    When FALSE (the default), and:
-  -- ,      - "pos" is "botleft" or "topleft", and
-  -- ,      - "wrap" is off, and
-  -- ,      - the popup would be truncated at the right edge of
-  -- ,        the screen, then
-  -- ,     the popup is moved to the left so as to fit the
-  -- ,     contents on the screen.  Set to TRUE to disable this.
-
-  win_opts.style = "minimal"
-
   -- Feels like maxheight, minheight, maxwidth, minwidth will all be related
   --
   -- maxheight  Maximum height of the contents, excluding border and padding.
@@ -171,6 +116,61 @@ function popup.create(what, vim_options)
   end
   win_opts.width = utils.bounded(width, vim_options.minwidth, vim_options.maxwidth)
   win_opts.height = utils.bounded(height, vim_options.minheight, vim_options.maxheight)
+
+  -- 
+  if vim_options.pos then
+    if vim_options.pos == "center" then
+      vim_options.line = 0
+      vim_options.col = 0
+      win_opts.anchor = "NW"
+    else
+      win_opts.anchor = popup._pos_map[vim_options.pos]
+    end
+  else
+    win_opts.anchor = "NW" -- This is the default, but makes `posinvert` easier to implement
+  end
+
+  local cursor_relative_pos = function(pos_str, dim)
+    assert(string.find(pos_str, "^cursor"), "Invalid value for " .. dim)
+    win_opts.relative = "cursor"
+    local line = 0
+    if (pos_str):match "cursor%+(%d+)" then
+      line = line + tonumber((pos_str):match "cursor%+(%d+)")
+    elseif (pos_str):match "cursor%-(%d+)" then
+      line = line - tonumber((pos_str):match "cursor%-(%d+)")
+    end
+    return line
+  end
+
+  if vim_options.line and vim_options.line ~= 0 then
+    if type(vim_options.line) == "string" then
+      win_opts.row = cursor_relative_pos(vim_options.line, "row")
+    else
+      win_opts.row = vim_options.line
+    end
+  else
+    win_opts.row = math.floor((vim.o.lines - win_opts.height)/2)
+  end
+
+  if vim_options.col and vim_options.col ~= 0 then
+    if type(vim_options.col) == "string" then
+      win_opts.col = cursor_relative_pos(vim_options.col, "col")
+    else
+      win_opts.col = vim_options.col
+    end
+  else
+    win_opts.col = math.floor((vim.o.columns - win_opts.width)/2)
+  end
+
+  -- , fixed    When FALSE (the default), and:
+  -- ,      - "pos" is "botleft" or "topleft", and
+  -- ,      - "wrap" is off, and
+  -- ,      - the popup would be truncated at the right edge of
+  -- ,        the screen, then
+  -- ,     the popup is moved to the left so as to fit the
+  -- ,     contents on the screen.  Set to TRUE to disable this.
+
+  win_opts.style = "minimal"
 
   -- posinvert, When FALSE the value of "pos" is always used.  When
   -- ,   TRUE (the default) and the popup does not fit

--- a/tests/plenary/strings_spec.lua
+++ b/tests/plenary/strings_spec.lua
@@ -46,19 +46,46 @@ describe("strings", function()
 
   describe("truncate", function()
     for _, case in ipairs {
-      { args = { "abcde", 6 }, expected = { single = "abcde", double = "abcde" } },
-      { args = { "abcde", 5 }, expected = { single = "abcde", double = "abcde" } },
-      { args = { "abcde", 4 }, expected = { single = "abc…", double = "ab…" } },
-      { args = { "アイウエオ", 11 }, expected = { single = "アイウエオ", double = "アイウエオ" } },
-      { args = { "アイウエオ", 10 }, expected = { single = "アイウエオ", double = "アイウエオ" } },
-      { args = { "アイウエオ", 9 }, expected = { single = "アイウエ…", double = "アイウ…" } },
-      { args = { "アイウエオ", 8 }, expected = { single = "アイウ…", double = "アイウ…" } },
-      { args = { "├─┤", 7 }, expected = { single = "├─┤", double = "├─┤" } },
-      { args = { "├─┤", 6 }, expected = { single = "├─┤", double = "├─┤" } },
-      { args = { "├─┤", 5 }, expected = { single = "├─┤", double = "├…" } },
-      { args = { "├─┤", 4 }, expected = { single = "├─┤", double = "├…" } },
-      { args = { "├─┤", 3 }, expected = { single = "├─┤", double = "…" } },
-      { args = { "├─┤", 2 }, expected = { single = "├…", double = "…" } },
+      -- truncations from the right
+      { args = { "abcde", 6, nil, 1 }, expected = { single = "abcde", double = "abcde" } },
+      { args = { "abcde", 5, nil, 1 }, expected = { single = "abcde", double = "abcde" } },
+      { args = { "abcde", 4, nil, 1 }, expected = { single = "abc…", double = "ab…" } },
+      {
+        args = { "アイウエオ", 11, nil, 1 },
+        expected = { single = "アイウエオ", double = "アイウエオ" }
+      },
+      {
+        args = { "アイウエオ", 10, nil, 1 },
+        expected = { single = "アイウエオ", double = "アイウエオ" }
+      },
+      { args = { "アイウエオ", 9, nil, 1 }, expected = { single = "アイウエ…", double = "アイウ…" } },
+      { args = { "アイウエオ", 8, nil, 1 }, expected = { single = "アイウ…", double = "アイウ…" } },
+      { args = { "├─┤", 7, nil, 1 }, expected = { single = "├─┤", double = "├─┤" } },
+      { args = { "├─┤", 6, nil, 1 }, expected = { single = "├─┤", double = "├─┤" } },
+      { args = { "├─┤", 5, nil, 1 }, expected = { single = "├─┤", double = "├…" } },
+      { args = { "├─┤", 4, nil, 1 }, expected = { single = "├─┤", double = "├…" } },
+      { args = { "├─┤", 3, nil, 1 }, expected = { single = "├─┤", double = "…" } },
+      { args = { "├─┤", 2, nil, 1 }, expected = { single = "├…", double = "…" } },
+      -- truncations from the left
+      { args = { "abcde", 6, nil, -1 }, expected = { single = "abcde", double = "abcde" } },
+      { args = { "abcde", 5, nil, -1 }, expected = { single = "abcde", double = "abcde" } },
+      { args = { "abcde", 4, nil, -1 }, expected = { single = "…cde", double = "…de" } },
+      {
+        args = { "アイウエオ", 11, nil, 1 },
+        expected = { single = "アイウエオ", double = "アイウエオ" }
+      },
+      {
+        args = { "アイウエオ", 10, nil, 1 },
+        expected = { single = "アイウエオ", double = "アイウエオ" }
+      },
+      { args = { "アイウエオ", 9, nil, -1 }, expected = { single = "…イウエオ", double = "…ウエオ" } },
+      { args = { "アイウエオ", 8, nil, -1 }, expected = { single = "…ウエオ", double = "…ウエオ" } },
+      { args = { "├─┤", 7, nil, -1 }, expected = { single = "├─┤", double = "├─┤" } },
+      { args = { "├─┤", 6, nil, -1 }, expected = { single = "├─┤", double = "├─┤" } },
+      { args = { "├─┤", 5, nil, -1 }, expected = { single = "├─┤", double = "…┤" } },
+      { args = { "├─┤", 4, nil, -1 }, expected = { single = "├─┤", double = "…┤" } },
+      { args = { "├─┤", 3, nil, -1 }, expected = { single = "├─┤", double = "…" } },
+      { args = { "├─┤", 2, nil, -1 }, expected = { single = "…┤", double = "…" } },
     } do
       for _, ambiwidth in ipairs { "single", "double" } do
         local msg = ("ambiwidth = %s, [%s, %d] -> %s"):format(

--- a/tests/plenary/strings_spec.lua
+++ b/tests/plenary/strings_spec.lua
@@ -52,11 +52,11 @@ describe("strings", function()
       { args = { "abcde", 4, nil, 1 }, expected = { single = "abc…", double = "ab…" } },
       {
         args = { "アイウエオ", 11, nil, 1 },
-        expected = { single = "アイウエオ", double = "アイウエオ" }
+        expected = { single = "アイウエオ", double = "アイウエオ" },
       },
       {
         args = { "アイウエオ", 10, nil, 1 },
-        expected = { single = "アイウエオ", double = "アイウエオ" }
+        expected = { single = "アイウエオ", double = "アイウエオ" },
       },
       { args = { "アイウエオ", 9, nil, 1 }, expected = { single = "アイウエ…", double = "アイウ…" } },
       { args = { "アイウエオ", 8, nil, 1 }, expected = { single = "アイウ…", double = "アイウ…" } },
@@ -72,11 +72,11 @@ describe("strings", function()
       { args = { "abcde", 4, nil, -1 }, expected = { single = "…cde", double = "…de" } },
       {
         args = { "アイウエオ", 11, nil, 1 },
-        expected = { single = "アイウエオ", double = "アイウエオ" }
+        expected = { single = "アイウエオ", double = "アイウエオ" },
       },
       {
         args = { "アイウエオ", 10, nil, 1 },
-        expected = { single = "アイウエオ", double = "アイウエオ" }
+        expected = { single = "アイウエオ", double = "アイウエオ" },
       },
       { args = { "アイウエオ", 9, nil, -1 }, expected = { single = "…イウエオ", double = "…ウエオ" } },
       { args = { "アイウエオ", 8, nil, -1 }, expected = { single = "…ウエオ", double = "…ウエオ" } },


### PR DESCRIPTION
Heavily based on the implementation from [this PR](https://github.com/nvim-lua/popup.nvim/pull/9) by @jesseleite.

Also, added options to center in only one direction using `0` for `row`/`line`.
This required shifting the indices of everything else by one, which is a bit annoying, but this is how the implementation in vim works, so 🤷
This does break stuff in telescope, so I will write a PR over there when I get a chance.