### PR TITLE
feat(benchmark): add util to benchmark functions

### DIFF
--- a/lua/plenary/benchmark/init.lua
+++ b/lua/plenary/benchmark/init.lua
@@ -20,27 +20,33 @@ local get_stat = function(start, runs, fun)
 end
 
 local get_output = function(name, res)
-  return ('  - ("%s") min: %.3fs, max: %.3fs, mean: %.3fs, median: %fs, std: %fs\n'):format(
-    name,
-    res.min,
-    res.max,
-    res.mean,
-    res.median,
-    res.std
-  )
+  local start = "  - "
+  if type(name) ~= "number" then
+    start = start .. ("[[%s]] "):format(name)
+  end
+
+  return start
+    .. ("min: %.3fs, max: %.3fs, mean: %.3fs, median: %fs, std: %fs\n"):format(
+      res.min,
+      res.max,
+      res.mean,
+      res.median,
+      res.std
+    )
 end
 
 ---@class benchmark_run_opts
 ---@field warmup number @number of initial runs before starting to track time.
 ---@field runs number @number of runs to make
----@field funs table<string, function> @function to execute
+---@field fun table<string, function>|function @function to execute
 
 ---Benchmark a function
 ---@param name string @benchmark name
 ---@param opts benchmark_run_opts
 local bench = function(name, opts)
+  opts.fun = type(opts.fun) == "function" and { opts.fun } or opts.fun
   for _ = 1, opts.warmup or 5 do
-    for _, fun in pairs(opts.funs) do
+    for _, fun in pairs(opts.fun) do
       fun()
     end
   end
@@ -48,7 +54,7 @@ local bench = function(name, opts)
 
   local output, res = "", {}
 
-  for k, fun in pairs(opts.funs) do
+  for k, fun in pairs(opts.fun) do
     res[k] = get_stat(start, opts.runs, fun)
     output = output .. get_output(k, res[k])
   end
@@ -56,11 +62,30 @@ local bench = function(name, opts)
   res.elapsed = vim.loop.hrtime() - start
 
   print(
-    ('("%s") Benchmark: \n\n  - total elapsed time: %.3fms\n  - runs: %s\n'):format(name, res.elapsed, opts.runs)
+    ("[[%s]] Benchmark: \n\n  - total elapsed time: %.3fms\n  - runs: %s\n"):format(name, res.elapsed, opts.runs)
       .. output
   )
 
   return res
 end
+
+-- bench("Predicting Y", {
+--   runs = 10,
+--   fun = function()
+--     vim.wait(200, function() end)
+--   end,
+-- })
+-- (slower / faster)
+bench("Predicting Y", {
+  runs = 5,
+  fun = {
+    base = function()
+      vim.wait(200, function() end)
+    end,
+    ench = function()
+      vim.wait(100, function() end)
+    end,
+  },
+})
 
 return bench

--- a/lua/plenary/benchmark/init.lua
+++ b/lua/plenary/benchmark/init.lua
@@ -14,14 +14,36 @@ end
 
 local get_output = function(index, res, runs)
   -- divine with a sutable one / 1e3, 1e6, 1e9
+  local time_types = { "ns", "μs", "ms" }
+
+  local get_leading = function(time)
+    time = math.floor(time)
+    local count = 0
+    repeat
+      time = math.floor(time / 10)
+      count = count + 1
+    until time <= 0
+    return count
+  end
+
+  local get_best_fmt = function(time)
+    for _, v in ipairs(time_types) do
+      if math.abs(time) < 1000.0 then
+        return string.format("%s%3.1f %s", string.rep(" ", 3 - get_leading(time)), time, v)
+      end
+      time = time / 1000.0
+    end
+    return string.format("%.1f %s", time, "s")
+  end
+
   return string.format(
-    "Benchmark #%d: '%s'\n  Time(mean ± σ):    %.1f ms ± %.1f ms\n  Range(min … max):  %.1f ms … %.1f ms  %d runs\n",
+    "Benchmark #%d: '%s'\n  Time(mean ± σ):    %s ± %s\n  Range(min … max):  %s … %s  %d runs\n",
     index,
     res.name,
-    res.stats.mean / 1e6,
-    res.stats.std / 1e6,
-    res.stats.min / 1e6,
-    res.stats.max / 1e6,
+    get_best_fmt(res.stats.mean),
+    get_best_fmt(res.stats.std),
+    get_best_fmt(res.stats.min),
+    get_best_fmt(res.stats.max),
     runs
   )
 end

--- a/lua/plenary/benchmark/init.lua
+++ b/lua/plenary/benchmark/init.lua
@@ -1,91 +1,104 @@
 local B = {}
 local stat = require "plenary.benchmark.stat"
 
-local get_stat = function(start, runs, fun)
-  local result = {}
-
-  for i = 1, runs do
-    fun()
-    result[i] = vim.loop.hrtime() - start
-  end
-
+local get_stats = function(results)
   local ret = {}
 
-  ret.max, ret.min = stat.maxmin(result)
-  ret.mean = stat.mean(result)
-  ret.median = stat.median(result)
-  ret.std = stat.std_dev(result)
+  ret.max, ret.min = stat.maxmin(results)
+  ret.mean = stat.mean(results)
+  ret.median = stat.median(results)
+  ret.std = stat.std_dev(results)
 
   return ret
 end
 
-local get_output = function(name, res)
-  local start = "  - "
-  if type(name) ~= "number" then
-    start = start .. ("[[%s]] "):format(name)
+local get_output = function(index, res, runs)
+  -- divine with a sutable one / 1e3, 1e6, 1e9
+  return string.format(
+    "Benchmark #%d: '%s'\n  Time(mean ± σ):    %.1f ms ± %.1f ms\n  Range(min … max):  %.1f ms … %.1f ms  %d runs\n",
+    index,
+    res.name,
+    res.stats.mean / 1e6,
+    res.stats.std / 1e6,
+    res.stats.min / 1e6,
+    res.stats.max / 1e6,
+    runs
+  )
+end
+
+local get_summary = function(res)
+  if #res == 1 then
+    return ""
   end
 
-  return start
-    .. ("min: %.3fs, max: %.3fs, mean: %.3fs, median: %fs, std: %fs\n"):format(
-      res.min,
-      res.max,
-      res.mean,
-      res.median,
-      res.std
-    )
+  local fastest_mean = math.huge
+  local fastest_index = 1
+  for i, benchmark in ipairs(res) do
+    if benchmark.stats.mean < fastest_mean then
+      fastest_mean = benchmark.stats.mean
+      fastest_index = i
+    end
+  end
+
+  if fastest_mean == math.huge then
+    return ""
+  end
+
+  local output = {}
+  local fastest = res[fastest_index].stats
+  for i, benchmark in ipairs(res) do
+    if i ~= fastest_index then
+      local result = benchmark.stats
+      local ratio = result.mean / fastest.mean
+
+      -- // https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulas
+      -- // Covariance asssumed to be 0, i.e. variables are assumed to be independent
+      local ratio_std = ratio
+        * math.sqrt(math.pow(result.std / result.mean, 2) + math.pow(fastest.std / fastest.mean, 2))
+
+      table.insert(output, string.format("  %.1f ± %.1f times faster than '%s'\n", ratio, ratio_std, benchmark.name))
+    end
+  end
+
+  return string.format("Summary\n  '%s' ran\n%s", res[fastest_index].name, table.concat(output, ""))
 end
 
 ---@class benchmark_run_opts
 ---@field warmup number @number of initial runs before starting to track time.
 ---@field runs number @number of runs to make
----@field fun table<string, function>|function @function to execute
+---@field fun table<array<string, function>> @functions to execute
 
 ---Benchmark a function
 ---@param name string @benchmark name
 ---@param opts benchmark_run_opts
 local bench = function(name, opts)
+  vim.validate {
+    opts = { opts, "table" },
+    fun = { opts.fun, "table" },
+  }
+  opts.warmup = vim.F.if_nil(opts.warmup, 3)
+  opts.runs = vim.F.if_nil(opts.runs, 5)
+
   opts.fun = type(opts.fun) == "function" and { opts.fun } or opts.fun
-  for _ = 1, opts.warmup or 5 do
-    for _, fun in pairs(opts.fun) do
-      fun()
+  local output = { string.format("Benchmark Group: '%s' -----------------------\n", name) }
+  local res = {}
+  for i, fun in ipairs(opts.fun) do
+    res[i] = { name = fun[1], results = {} }
+    for _ = 1, opts.warmup do
+      fun[2]()
     end
+    for j = 1, opts.runs do
+      local start = vim.loop.hrtime()
+      fun[2]()
+      res[i].results[j] = vim.loop.hrtime() - start
+    end
+    res[i].stats = get_stats(res[i].results)
+    table.insert(output, get_output(i, res[i], opts.runs))
   end
-  local start = vim.loop.hrtime()
 
-  local output, res = "", {}
-
-  for k, fun in pairs(opts.fun) do
-    res[k] = get_stat(start, opts.runs, fun)
-    output = output .. get_output(k, res[k])
-  end
-
-  res.elapsed = vim.loop.hrtime() - start
-
-  print(
-    ("[[%s]] Benchmark: \n\n  - total elapsed time: %.3fms\n  - runs: %s\n"):format(name, res.elapsed, opts.runs)
-      .. output
-  )
+  print(string.format("%s\n%s", table.concat(output, ""), get_summary(res)))
 
   return res
 end
-
--- bench("Predicting Y", {
---   runs = 10,
---   fun = function()
---     vim.wait(200, function() end)
---   end,
--- })
--- (slower / faster)
-bench("Predicting Y", {
-  runs = 5,
-  fun = {
-    base = function()
-      vim.wait(200, function() end)
-    end,
-    ench = function()
-      vim.wait(100, function() end)
-    end,
-  },
-})
 
 return bench

--- a/lua/plenary/benchmark/init.lua
+++ b/lua/plenary/benchmark/init.lua
@@ -1,0 +1,74 @@
+local B = {}
+local stat = require "plenary.benchmark.stat"
+
+local get_stat = function(runs, fun)
+  local result = {}
+  local start = vim.loop.hrtime()
+
+  for i = 1, runs do
+    fun()
+    result[i] = vim.loop.hrtime() - start
+  end
+
+  local ret = {}
+
+  ret.elapsed = vim.loop.hrtime() - start
+  ret.max, ret.min = stat.maxmin(result)
+  ret.mean = stat.mean(result)
+  ret.median = stat.median(result)
+  ret.std = stat.std_dev(result)
+
+  return ret
+end
+
+---@class benchmark_run_opts
+---@field warmup number @number of initial runs before starting to track time.
+---@field runs number @number of runs to make
+---@field fun function @function to execute
+
+---Benchmark a function
+---@param name string @benchmark name
+---@param opts benchmark_run_opts
+B.run = function(name, opts)
+  for i = 1, opts.warmup do
+    opts.fun()
+  end
+
+  local res = get_stat(opts.runs, opts.fun)
+
+  print(('("%s") Benchmark: \n\n  - total elapsed time: %.3fms'):format(name, res.elapsed))
+  print("  - runs: " .. opts.runs)
+  print(
+    ("  - min: %.3fs, max: %.3fs, mean: %.3fs, median: %fs, std: %fs\n"):format(
+      res.min,
+      res.max,
+      res.mean,
+      res.median,
+      res.std
+    )
+  )
+
+  return res
+end
+
+---@class benchmark_compare_opts
+---@field warmup number @number of initial runs before starting to track time.
+---@field runs number @number of runs to make
+---@field new function @function to test
+---@field base function @function to compare against
+
+---Compare between {fun1} and {fun1} results
+---@param name string @benchmark name
+---@param opts benchmark_compare_opts
+B.compare = function(name, opts)
+  for i = 1, opts.warmuwarmup do
+    opts.new()
+    opts.base()
+  end
+
+  local base_result = get_stat(opts.runs, opts.base)
+  local new_result = get_stat(opts.runs, opts.new)
+  ---
+end
+
+return B

--- a/lua/plenary/benchmark/stat.lua
+++ b/lua/plenary/benchmark/stat.lua
@@ -1,0 +1,86 @@
+local stat = {}
+
+---Calculate mean
+---@param t number[] @double
+---@return number @double
+stat.mean = function(t)
+  local sum = 0
+  local count = 0
+
+  for _, v in pairs(t) do
+    if type(v) == "number" then
+      sum = sum + v
+      count = count + 1
+    end
+  end
+
+  return (sum / count)
+end
+
+-- Get the median of a table.
+---@param t number[]
+---@return number
+stat.median = function(t)
+  local temp = {}
+
+  -- deep copy table so that when we sort it, the original is unchanged
+  -- also weed out any non numbers
+  for _, v in pairs(t) do
+    if type(v) == "number" then
+      table.insert(temp, v)
+    end
+  end
+
+  table.sort(temp)
+
+  -- If we have an even number of table elements or odd.
+  if math.fmod(#temp, 2) == 0 then
+    -- return mean value of middle two elements
+    return (temp[#temp / 2] + temp[(#temp / 2) + 1]) / 2
+  else
+    -- return middle element
+    return temp[math.ceil(#temp / 2)]
+  end
+end
+
+--- Get the standard deviation of a table
+---@param t number[]
+stat.std_dev = function(t)
+  local m, vm, result
+  local sum = 0
+  local count = 0
+
+  m = stat.mean(t)
+
+  for _, v in pairs(t) do
+    if type(v) == "number" then
+      vm = v - m
+      sum = sum + (vm * vm)
+      count = count + 1
+    end
+  end
+
+  result = math.sqrt(sum / (count - 1))
+
+  return result
+end
+
+---Get the max and min for a table
+---@param t number[]
+---@return number
+---@return number
+stat.maxmin = function(t)
+  local max = -math.huge
+  local min = math.huge
+
+  for _, v in pairs(t) do
+    if type(v) == "number" then
+      max = math.max(max, v)
+      min = math.min(min, v)
+    end
+  end
+
+  return max, min
+end
+
+return stat

--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -56,6 +56,10 @@ function harness.test_directory(directory, opts)
     if res.border_win_id then
       vim.api.nvim_win_set_option(res.border_win_id, "winhl", "Normal:Normal")
     end
+
+    if res.bufnr then
+      vim.api.nvim_buf_set_option(res.bufnr, "filetype", "PlenaryTestPopup")
+    end
     vim.cmd "mode"
   end
 


### PR DESCRIPTION
Trying to add a way in which we can tests the performance and improve it. I'd like to have this be part of busted run test output somehow. maybe through a global variable 'bench_run', 'bench_compare'

example:
```lua
becnh_run("predicting y", {
  warmup = 4, -- number of runs before start calculating
  runs = 100, -- number of runs 
  fun = function()  -- function to test
    vim.wait(400, function() end)
   end
})
```

output 

```lua
("predicting y") Benchmark:
  - total elapsed time: 492591167.000ms
  - runs: 100
  - min: 5031917.000s, max: 492584084.000s, mean: 247768180.710s, median: 246534042.000000s, std: 142929375.485669s
```

not sure how to do compare yet