### PR TITLE
fix: don't try to parse response on curl nonzero exit

### DIFF
--- a/lua/plenary/curl.lua
+++ b/lua/plenary/curl.lua
@@ -244,6 +244,15 @@ request = function(specs)
     command = "curl",
     args = args,
     on_exit = function(j, code)
+      if code ~= 0 then
+        error(string.format(
+          "%s %s - curl error exit_code=%s stderr=%s",
+          opts.method,
+          opts.url,
+          code,
+          vim.inspect(j:stderr_result())
+        ))
+      end
       local output = parse.response(j:result(), opts.dump[2], code)
       if opts.callback then
         return opts.callback(output)


### PR DESCRIPTION
If curl exits with a nonzero exit code, don't try parsing a response, which may result in an error like (from #176)
```
E5113: Error while calling lua chunk: ...Data\Local\nvim\plugged\plenary.nvim\lua\plenary\job.lua:495: 'curl -sSL -D /tmp/plenary_curl_b69140fb.headers --compressed -X GET -H Accept: application/json https://postman-echo.com/get' wa
s unable to complete in 10000 ms
Error executing luv callback:
...ata\Local\nvim\plugged\plenary.nvim\lua\plenary\path.lua:571: ENOENT: no such file or directory: /tmp/plenary_curl_b69140fb.headers
```

Instead raise a more helpful error detailing the curl exit code and stderr output.

![Screenshot 2021-09-18 114006](https://user-images.githubusercontent.com/2990876/133886049-c5235deb-9447-45b9-8b44-5e744002647a.png)

This won't resolve #176 but at least gives a hint as to what the issue might be e.g. in my case it was that my `curl` does not have compression enabled.

