### PR TITLE
fix(border): Failing to display if row negative

### DIFF
--- a/lua/plenary/window/border.lua
+++ b/lua/plenary/window/border.lua
@@ -73,7 +73,17 @@ function Border._create_lines(content_win_options, border_win_options)
     or border_win_options.title
     or {}
 
-  if content_win_options.row > 0 then
+  --[[
+  --  Ensure that the topline is drawn only if the row is positive (for an absolute position) or if when added to the current
+  --  cursor line (for a cursor relative position) it is also a positive value.
+  --]]
+  if
+    content_win_options.row > 0
+    or (
+      content_win_options.relative == "cursor"
+      and content_win_options.row + vim.api.nvim_win_get_cursor(0)[1] + vim.api.nvim_win_get_position(0)[1] > 1
+    )
+  then
     for _, title in ipairs(titles) do
       if string.find(title.pos, "N") then
         topline = create_horizontal_line(
@@ -92,6 +102,8 @@ function Border._create_lines(content_win_options, border_win_options)
         topline = topleft .. string.rep(border_win_options.top, content_win_options.width) .. topright
       end
     end
+  else
+    border_win_options.border_thickness.top = 0
   end
 
   if topline then


### PR DESCRIPTION
Fixes GH-239

# Proposed changes

* Modify the `if` statement checking that the row is positive and non-zero for a `Border`, by allowing negative values for cursor-relative row numbers, if they are not outside of bounds
* Add an `else` branch to remove top border thickness if the `topline` should not be drawn

## Motivation behind changes

As described in GH-239, this commit aims to fix an issue with the Border component, which makes it impossible to draw the top and bottom lines and makes the middle line replace the former, if the row is a negative value. This also makes it impossible to use the `planery.popup` cursor-relative positioning, as a value such as 'cursor-2' would break the popup.

### Test plan

Tests from the `tests` and `lua/luassert` directories are used for validation, as I am not too familiar with the current code base. If others should be made, please let me know so as to add them.
