### PR TITLE
feat: copy directories recursively

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -500,40 +500,69 @@ function Path:rename(opts)
   return status
 end
 
+--- Copy files and folders.
+---@param opts table: options to pass to toggling registered actions
+---@field destination string|Path: target file path to copy to
+---@field recursive bool: whether to copy folders recursively (default: true)
+---@field override bool: whether to override files (default: true)
+---@field interactive bool: confirm if copy would override; precedes `override` (default: false)
+---@field respect_gitignore bool: skip folders ignored by all detected `gitignore`s (default: true)
+---@field hidden bool: whether to add hidden files in recursively copying folders (default: true)
+---@return table {Path: bool} indicating sucess of copy; nested tables constitute sub dirs
 function Path:copy(opts)
   opts = opts or {}
   opts.recursive = F.if_nil(opts.recursive, false, opts.recursive)
+  opts.override = F.if_nil(opts.override, true, opts.override)
 
+  local dest = opts.destination
   -- handles `.`, `..`, `./`, and `../`
-  if opts.destination:match "^%.%.?/?\\?.+" then
-    opts.destination = {
-      uv.fs_realpath(opts.destination:sub(1, 3)),
-      opts.destination:sub(4, #opts.destination),
-    }
+  if not Path.is_path(dest) then
+    if type(dest) == "string" and dest:match "^%.%.?/?\\?.+" then
+      dest = {
+        uv.fs_realpath(dest:sub(1, 3)),
+        dest:sub(4, #dest),
+      }
+    end
+    dest = Path:new(dest)
   end
-  local dest = Path:new(opts.destination)
-
+  -- success is true in case file is copied, false otherwise
+  local success = {}
   if not self:is_dir() then
-    return uv.fs_copyfile(self:absolute(), dest:absolute(), { excl = true })
+    local flags = {}
+    if opts.interactive and dest:exists() then
+      vim.ui.select({ "Yes", "No" }, { prompt = string.format("Overwrite existing %s?", dest:absolute()) }, function(_, idx)
+        success[self] = uv.fs_copyfile(self:absolute(), dest:absolute(), { excl = not (idx == 1) }) or false
+      end)
+    else
+      flags.excl = not opts.override
+      -- nil: not overriden if `override = false`
+      success[self] = uv.fs_copyfile(self:absolute(), dest:absolute(), flags) or false
+    end
+    return success
   end
   if opts.recursive then
     dest:mkdir {
       parents = F.if_nil(opts.parents, true, opts.parents),
-      exists_ok = F.if_nil(opts.exists_ok, true, opts.exists),
+      exists_ok = F.if_nil(opts.exists_ok, true, opts.exists_ok),
     }
     local scan = require "plenary.scandir"
     local data = scan.scan_dir(self.filename, {
       respect_gitignore = F.if_nil(opts.respect_gitignore, true, opts.respect_gitignore),
       hidden = F.if_nil(opts.hidden, true, opts.hidden),
       depth = 1,
-      add_dirs = F.if_nil(opts.add_dirs, true, opts.add_dirs),
+      add_dirs = true,
     })
     for _, entry in ipairs(data) do
       local entry_path = Path:new(entry)
       local suffix = table.remove(entry_path:_split())
-      local new_opts = vim.tbl_deep_extend("force", opts, { destination = dest:joinpath(suffix).filename })
-      return entry_path:copy(new_opts)
+      local new_dest = dest:joinpath(suffix)
+      -- clear destination as it might be Path table otherwise failing w/ extend
+      opts.destination = nil
+      local new_opts = vim.tbl_deep_extend("force", opts, { destination = new_dest })
+      -- nil: not overriden if `override = false`
+      success[entry_path] = entry_path:copy(new_opts) or false
     end
+    return success
   end
 end
 

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -521,21 +521,18 @@ function Path:copy(opts)
       parents = F.if_nil(opts.parents, true, opts.parents),
       exists_ok = F.if_nil(opts.exists_ok, true, opts.exists),
     }
-    local data = {}
     local scan = require "plenary.scandir"
-    scan.scan_dir(self.filename, {
+    local data = scan.scan_dir(self.filename, {
       respect_gitignore = F.if_nil(opts.respect_gitignore, true, opts.respect_gitignore),
-      hidden = F.if_nil(opts.hidden, false, opts.hidden),
+      hidden = F.if_nil(opts.hidden, true, opts.hidden),
       depth = 1,
       add_dirs = F.if_nil(opts.add_dirs, true, opts.add_dirs),
-      on_insert = function(entry)
-        table.insert(data, Path:new(entry))
-      end,
     })
-    for _, path_ in ipairs(data) do
-      local suffix = table.remove(path_:_split())
+    for _, entry in ipairs(data) do
+      local entry_path = Path:new(entry)
+      local suffix = table.remove(entry_path:_split())
       local new_opts = vim.tbl_deep_extend("force", opts, { destination = dest:joinpath(suffix).filename })
-      return path_:copy(new_opts)
+      return entry_path:copy(new_opts)
     end
   end
 end

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -429,11 +429,13 @@ function Path:mkdir(opts)
   local parents = F.if_nil(opts.parents, false, opts.parents)
   local exists_ok = F.if_nil(opts.exists_ok, true, opts.exists_ok)
 
-  if not exists_ok and self:exists() then
+  local exists = self:exists()
+  if not exists_ok and exists then
     error("FileExistsError:" .. self:absolute())
   end
 
-  if not uv.fs_mkdir(self:_fs_filename(), mode) then
+  -- fs_mkdir returns nil if folder exists
+  if not uv.fs_mkdir(self:_fs_filename(), mode) and not exists then
     if parents then
       local dirs = self:_split()
       local processed = ""

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -500,20 +500,20 @@ function Path:rename(opts)
   return status
 end
 
---- Copy files or folders.
+--- Copy files or folders with defaults akin to GNU's `cp`.
 ---@param opts table: options to pass to toggling registered actions
 ---@field destination string|Path: target file path to copy to
----@field recursive bool: whether to copy folders recursively (default: true)
+---@field recursive bool: whether to copy folders recursively (default: false)
 ---@field override bool: whether to override files (default: true)
 ---@field interactive bool: confirm if copy would override; precedes `override` (default: false)
 ---@field respect_gitignore bool: skip folders ignored by all detected `gitignore`s (default: false)
 ---@field hidden bool: whether to add hidden files in recursively copying folders (default: true)
----@field parents bool: whether to create possibly non-existing parent dirs of `opts.destination` (default: true)
+---@field parents bool: whether to create possibly non-existing parent dirs of `opts.destination` (default: false)
 ---@field exists_ok bool: whether ok if `opts.destination` exists, if so folders are merged (default: true)
 ---@return table {[Path of destination]: bool} indicating success of copy; nested tables constitute sub dirs
 function Path:copy(opts)
   opts = opts or {}
-  opts.recursive = F.if_nil(opts.recursive, true, opts.recursive)
+  opts.recursive = F.if_nil(opts.recursive, false, opts.recursive)
   opts.override = F.if_nil(opts.override, true, opts.override)
 
   local dest = opts.destination
@@ -547,7 +547,7 @@ function Path:copy(opts)
   -- dir
   if opts.recursive then
     dest:mkdir {
-      parents = F.if_nil(opts.parents, true, opts.parents),
+      parents = F.if_nil(opts.parents, false, opts.parents),
       exists_ok = F.if_nil(opts.exists_ok, true, opts.exists_ok),
     }
     local scan = require "plenary.scandir"

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -470,9 +470,8 @@ describe("Path", function()
 
       local trg_dir = Path:new "trg"
       local status = xpcall(function()
-        src_dir:copy { destination = trg_dir, recursive = false, override = override, hidden = hidden }
+        src_dir:copy { destination = trg_dir, recursive = false }
       end, function()
-        return
       end)
       -- failed as intended
       assert(status == false)

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -471,8 +471,7 @@ describe("Path", function()
       local trg_dir = Path:new "trg"
       local status = xpcall(function()
         src_dir:copy { destination = trg_dir, recursive = false }
-      end, function()
-      end)
+      end, function() end)
       -- failed as intended
       assert(status == false)
 


### PR DESCRIPTION
Extends `Path:copy` to recursively copy folders for https://github.com/nvim-telescope/telescope.nvim/pull/1257

This is pretty much the plenary equivalent of how nvim_tree performs copying [here](https://github.com/kyazdani42/nvim-tree.lua/blob/d7f73b5ae9c8fa85535c32e2861c2cb97df5d56b/lua/nvim-tree/fs.lua#L146).

E: tests are TODO