### PR TITLE
path: fix for normalizing files including ...

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -83,7 +83,7 @@ local function _normalize_path(filename)
 
   local out_file = filename
 
-  local has = string.find(filename, "..", 1, true)
+  local has = string.find(filename, "/..", 1, true) or string.find(filename, "../", 1, true)
 
   if has then
     local parts = _split_by_separator(filename)

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -185,6 +185,15 @@ describe("Path", function()
       local final = Path:new(orig):normalize()
       assert.are.same(final, "/lua/plenary/path.lua")
     end)
+
+    it("can normalize paths containing ...", function()
+      assert.are.same(Path:new(vim.fn.fnameescape("[...test].txt")):normalize(vim.loop.cwd()), "\\[...test].txt")
+    end)
+
+    it("can normalize paths containing both .. and ...", function()
+      assert.are.same(Path:new(vim.fn.fnameescape("dir1/dir2/../[...test].txt")):normalize(vim.loop.cwd()), "dir1/\\[...test].txt")
+    end)
+
   end)
 
   describe(":shorten", function()


### PR DESCRIPTION
The change I made to `path.lua` fixes the issue apart from when the paths also has `..` segments. I could use some help figuring that part out. I think it's to do with `path.root()` but I'm not too sure why the behaviour is affected by the filename as I'm on linux and from what I can tell, that will always return `/`?

### Todo
- [x] Properly normalize files containing `...`, i.e. `dir1/[...test].ts`
- [ ] Properly normalize files containing both `...` and `..` segments, i.e. `dir1/dir2/../[...test].ts`