### PR TITLE
feat: more json filetypes

### DIFF
--- a/data/plenary/filetypes/builtin.lua
+++ b/data/plenary/filetypes/builtin.lua
@@ -41,6 +41,10 @@ return {
   },
   file_name = {
     ['cakefile'] = 'coffee',
+    ['.babelrc'] = 'json',
+    ['.prettierrc'] = 'json',
+    ['.eslintrc'] = 'json',
+    ['.firebaserc'] = 'json',
   },
   shebang = shebang
 }


### PR DESCRIPTION
Following what has been done here: https://github.com/vim/vim/issues/8947

I added these filetypes to Plenary so they can be previewed in Telescope:

![image](https://user-images.githubusercontent.com/58179604/136121947-67837da5-d1b0-475c-8298-ca56cdeee8f9.png)
