### PR TITLE
expand environment variables surrounded with braces

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -276,10 +276,10 @@ function Path:expand()
       expanded = vim.fn.fnamemodify(self.filename, ":p")
     end
   elseif string.find(self.filename, "%$") then
-    local rep = string.match(self.filename, "([^%$][^/]*)")
+    local rep = string.match(self.filename, "([^%${][^}/]*)")
     local val = os.getenv(rep)
     if val then
-      expanded = string.gsub(string.gsub(self.filename, rep, val), "%$", "")
+      expanded = string.gsub(string.gsub(self.filename, rep, val), "[%${}]", "")
     else
       expanded = nil
     end


### PR DESCRIPTION
I hope to expand below environment variables with Path.expand(). 
So, fix regexp for capture in Path.expand.

```toml
memodir = "${XDG_CONFIG_HOME}/memo/_posts"
```