### PR TITLE
Initialise ranges

### DIFF
--- a/lua/plenary/window/border.lua
+++ b/lua/plenary/window/border.lua
@@ -46,7 +46,7 @@ local create_horizontal_line = function(title, pos, width, left_char, mid_char, 
     string.rep(mid_char, width - title_len - left_start),
     right_char
   )
-  local ranges
+  local ranges = {}
   if title_len ~= 0 then
     -- Need to calculate again due to multi-byte characters
     local r_start = string.len(left_char) + math.max(left_start, 0) * string.len(mid_char)


### PR DESCRIPTION
Resolves a bug where windows without titles would error. 

Not sure of any other implications of adding this, so I'm open to other resolutions :)