### PR TITLE
fix: check if `Border` title ranges is the empty table

### DIFF
--- a/lua/plenary/window/border.lua
+++ b/lua/plenary/window/border.lua
@@ -164,7 +164,8 @@ function Border._create_lines(content_win_options, border_win_options)
 end
 
 local set_title_highlights = function(bufnr, ranges, hl)
-  if hl and ranges then
+  -- Check if both `hl` and `ranges` are provided, and `ranges` is not the empty table.
+  if hl and ranges and next(ranges) then
     for _, r in pairs(ranges) do
       vim.api.nvim_buf_add_highlight(bufnr, -1, hl, r[1], r[2], r[3])
     end


### PR DESCRIPTION
Adds a small extra check after changes in #265.

Doesn't change any functionality for the moment, but makes sure we don't get any confusing behaviour in the future.