### PR TITLE
feat: exclude positions in `Path:shorten`

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -324,23 +324,41 @@ function Path:normalize(cwd)
   return _normalize_path(self.filename)
 end
 
-local function shorten_len(filename, len)
-  local final_match
+local function shorten_len(filename, len, exclude)
+  exclude = exclude or {-1}
+  local exc = {}
+
+  -- get parts in a table
+  local parts = (function()
+    local r = {}
+    for m in (filename .. path.sep):gmatch("(.-)" .. path.sep) do
+      r[#r+1] = m
+    end
+    return r
+  end)()
+
+  for _, v in pairs(exclude) do
+    if v < 0 then
+      exc[v + #parts + 1] = true
+    else
+      exc[v] = true
+    end
+  end
+
   local final_path_components = {}
-  for match in (filename .. path.sep):gmatch("(.-)" .. path.sep) do
-    if #match > len then
+  local count = 1
+  for _, match in ipairs(parts) do
+    if not exc[count] and #match > len then
       table.insert(final_path_components, string.sub(match, 1, len))
     else
       table.insert(final_path_components, match)
     end
     table.insert(final_path_components, path.sep)
-    final_match = match
+    count = count + 1
   end
 
   local l = #final_path_components -- so that we don't need to keep calculating length
   table.remove(final_path_components, l) -- remove final slash
-  table.remove(final_path_components, l - 1) -- remvove shortened final component
-  table.insert(final_path_components, final_match) -- insert full final component
 
   return table.concat(final_path_components)
 end
@@ -367,10 +385,10 @@ local shorten = (function()
   end
 end)()
 
-function Path:shorten(len)
+function Path:shorten(len, exclude)
   assert(len ~= 0, "len must be at least 1")
   if len and len > 1 then
-    return shorten_len(self.filename, len)
+    return shorten_len(self.filename, len, exclude)
   end
   return shorten(self.filename)
 end

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -325,6 +325,7 @@ function Path:normalize(cwd)
 end
 
 local function shorten_len(filename, len, exclude)
+  len = len or 1
   exclude = exclude or {-1}
   local exc = {}
 
@@ -387,7 +388,7 @@ end)()
 
 function Path:shorten(len, exclude)
   assert(len ~= 0, "len must be at least 1")
-  if len and len > 1 then
+  if (len and len > 1) or exclude ~= nil then
     return shorten_len(self.filename, len, exclude)
   end
   return shorten(self.filename)

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -326,14 +326,14 @@ end
 
 local function shorten_len(filename, len, exclude)
   len = len or 1
-  exclude = exclude or {-1}
+  exclude = exclude or { -1 }
   local exc = {}
 
   -- get parts in a table
   local parts = (function()
     local r = {}
     for m in (filename .. path.sep):gmatch("(.-)" .. path.sep) do
-      r[#r+1] = m
+      r[#r + 1] = m
     end
     return r
   end)()

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -331,8 +331,13 @@ local function shorten_len(filename, len, exclude)
 
   -- get parts in a table
   local parts = {}
+  local empty_pos = {}
   for m in (filename .. path.sep):gmatch("(.-)" .. path.sep) do
-    parts[#parts + 1] = m
+    if m ~= "" then
+      parts[#parts + 1] = m
+    else
+      table.insert(empty_pos, #parts + 1)
+    end
   end
 
   for _, v in pairs(exclude) do
@@ -357,6 +362,11 @@ local function shorten_len(filename, len, exclude)
 
   local l = #final_path_components -- so that we don't need to keep calculating length
   table.remove(final_path_components, l) -- remove final slash
+
+  -- add back empty positions
+  for i = #empty_pos, 1, -1 do
+    table.insert(final_path_components, empty_pos[i], path.sep)
+  end
 
   return table.concat(final_path_components)
 end

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -330,13 +330,10 @@ local function shorten_len(filename, len, exclude)
   local exc = {}
 
   -- get parts in a table
-  local parts = (function()
-    local r = {}
-    for m in (filename .. path.sep):gmatch("(.-)" .. path.sep) do
-      r[#r + 1] = m
-    end
-    return r
-  end)()
+  local parts = {}
+  for m in (filename .. path.sep):gmatch("(.-)" .. path.sep) do
+    parts[#parts + 1] = m
+  end
 
   for _, v in pairs(exclude) do
     if v < 0 then

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -212,36 +212,36 @@ describe("Path", function()
 
     it("can shorten a path's components when excluding parts", function()
       local long_path = "/this/is/a/long/path"
-      local short_path = Path:new(long_path):shorten(nil, {1, -1})
+      local short_path = Path:new(long_path):shorten(nil, { 1, -1 })
       assert.are.same(short_path, "/this/i/a/l/path")
 
       -- without the leading /
       long_path = "this/is/a/long/path"
-      short_path = Path:new(long_path):shorten(nil, {1, -1})
+      short_path = Path:new(long_path):shorten(nil, { 1, -1 })
       assert.are.same(short_path, "this/i/a/l/path")
 
       -- where excluding positions greater than the number of parts
       long_path = "this/is/an/extremely/long/path"
-      short_path = Path:new(long_path):shorten(nil, {2, 4, 6, 8})
+      short_path = Path:new(long_path):shorten(nil, { 2, 4, 6, 8 })
       assert.are.same(short_path, "t/is/a/extremely/l/path")
 
       -- where excluding positions less than the negation of the number of parts
       long_path = "this/is/an/extremely/long/path"
-      short_path = Path:new(long_path):shorten(nil, {-2, -4, -6, -8})
+      short_path = Path:new(long_path):shorten(nil, { -2, -4, -6, -8 })
       assert.are.same(short_path, "this/i/an/e/long/p")
     end)
 
     it("can shorten a path's components to a given length and exclude positions", function()
       local long_path = "/this/is/a/long/path"
-      local short_path = Path:new(long_path):shorten(2, {1, -1})
+      local short_path = Path:new(long_path):shorten(2, { 1, -1 })
       assert.are.same(short_path, "/this/is/a/lo/path")
 
       long_path = "this/is/a/long/path"
-      short_path = Path:new(long_path):shorten(3, {2, -2})
+      short_path = Path:new(long_path):shorten(3, { 2, -2 })
       assert.are.same(short_path, "thi/is/a/long/pat")
 
       long_path = "this/is/an/extremely/long/path"
-      short_path = Path:new(long_path):shorten(5, {3, -3})
+      short_path = Path:new(long_path):shorten(5, { 3, -3 })
       assert.are.same(short_path, "this/is/an/extremely/long/path")
     end)
   end)

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -193,10 +193,8 @@ describe("Path", function()
       local short_path = Path:new(long_path):shorten()
       assert.are.same(short_path, "/t/i/a/l/path")
     end)
-  end)
 
-  describe(":shorten", function()
-    it("can shorten a path components to a given length", function()
+    it("can shorten a path's components to a given length", function()
       local long_path = "/this/is/a/long/path"
       local short_path = Path:new(long_path):shorten(2)
       assert.are.same(short_path, "/th/is/a/lo/path")
@@ -210,6 +208,41 @@ describe("Path", function()
       long_path = "this/is/an/extremely/long/path"
       short_path = Path:new(long_path):shorten(5)
       assert.are.same(short_path, "this/is/an/extre/long/path")
+    end)
+
+    it("can shorten a path's components when excluding parts", function()
+      local long_path = "/this/is/a/long/path"
+      local short_path = Path:new(long_path):shorten(nil, {1, -1})
+      assert.are.same(short_path, "/this/i/a/l/path")
+
+      -- without the leading /
+      long_path = "this/is/a/long/path"
+      short_path = Path:new(long_path):shorten(nil, {1, -1})
+      assert.are.same(short_path, "this/i/a/l/path")
+
+      -- where excluding positions greater than the number of parts
+      long_path = "this/is/an/extremely/long/path"
+      short_path = Path:new(long_path):shorten(nil, {2, 4, 6, 8})
+      assert.are.same(short_path, "t/is/a/extremely/l/path")
+
+      -- where excluding positions less than the negation of the number of parts
+      long_path = "this/is/an/extremely/long/path"
+      short_path = Path:new(long_path):shorten(nil, {-2, -4, -6, -8})
+      assert.are.same(short_path, "this/i/an/e/long/p")
+    end)
+
+    it("can shorten a path's components to a given length and exclude positions", function()
+      local long_path = "/this/is/a/long/path"
+      local short_path = Path:new(long_path):shorten(2, {1, -1})
+      assert.are.same(short_path, "/this/is/a/lo/path")
+
+      long_path = "this/is/a/long/path"
+      short_path = Path:new(long_path):shorten(3, {2, -2})
+      assert.are.same(short_path, "thi/is/a/long/pat")
+
+      long_path = "this/is/an/extremely/long/path"
+      short_path = Path:new(long_path):shorten(5, {3, -3})
+      assert.are.same(short_path, "this/is/an/extremely/long/path")
     end)
   end)
 

--- a/tests/plenary/strings_spec.lua
+++ b/tests/plenary/strings_spec.lua
@@ -78,7 +78,10 @@ describe("strings", function()
         args = { "アイウエオ", 10, nil, 1 },
         expected = { single = "アイウエオ", double = "アイウエオ" },
       },
-      { args = { "アイウエオ", 9, nil, -1 }, expected = { single = "…イウエオ", double = "…ウエオ" } },
+      {
+        args = { "アイウエオ", 9, nil, -1 },
+        expected = { single = "…イウエオ", double = "…ウエオ" }
+      },
       { args = { "アイウエオ", 8, nil, -1 }, expected = { single = "…ウエオ", double = "…ウエオ" } },
       { args = { "├─┤", 7, nil, -1 }, expected = { single = "├─┤", double = "├─┤" } },
       { args = { "├─┤", 6, nil, -1 }, expected = { single = "├─┤", double = "├─┤" } },

--- a/tests/plenary/strings_spec.lua
+++ b/tests/plenary/strings_spec.lua
@@ -80,7 +80,7 @@ describe("strings", function()
       },
       {
         args = { "アイウエオ", 9, nil, -1 },
-        expected = { single = "…イウエオ", double = "…ウエオ" }
+        expected = { single = "…イウエオ", double = "…ウエオ" },
       },
       { args = { "アイウエオ", 8, nil, -1 }, expected = { single = "…ウエオ", double = "…ウエオ" } },
       { args = { "├─┤", 7, nil, -1 }, expected = { single = "├─┤", double = "├─┤" } },


### PR DESCRIPTION
Allows you to specify certain positions that are excluded when shortening a path.

Currently when shortening a path, we shorten every section of the head of the path, leaving the last section (the tail) alone. This PR allows you to specify which positions you want to exclude from the shortening, by giving a list of positions.
For example:
- using `exclude={-1}` gives the default behaviour mentioned above
- using `exclude={1,-1}` shortens every section of the head of the path, apart from the first one
- using `exclude={2,-2}` shortens every section of the path apart from the 2nd from the beginning, and second from the end (so this will shorten the tail of the path unless the path has exactly two parts)

Inspired by [this](https://github.com/nvim-telescope/telescope.nvim/issues/880) issue in telescope.
I sorted part of the issue a while back and forgot about the rest until now 😅 

More examples:
![image](https://user-images.githubusercontent.com/35707277/139526784-03f7ee73-d77c-48ff-a1f9-516dcc4a8c63.png)
