### PR TITLE
popup: Allow user to force window size

### DIFF
--- a/lua/plenary/popup/init.lua
+++ b/lua/plenary/popup/init.lua
@@ -177,14 +177,16 @@ function popup.create(what, vim_options)
     zindex = 50,
   }
 
-  vim_options.width = if_nil(vim_options.width, 1)
-  if type(what) == "number" then
-    vim_options.height = vim.api.nvim_buf_line_count(what)
-  else
-    for _, v in ipairs(what) do
-      vim_options.width = math.max(vim_options.width, #v)
+  if not vim_options.force_size then
+    vim_options.width = if_nil(vim_options.width, 1)
+    if type(what) == "number" then
+      vim_options.height = vim.api.nvim_buf_line_count(what)
+    else
+      for _, v in ipairs(what) do
+        vim_options.width = math.max(vim_options.width, #v)
+      end
+      vim_options.height = #what
     end
-    vim_options.height = #what
   end
 
   local win_opts = {}


### PR DESCRIPTION
Came across this when trying to do a popup terminal window using `:h termopen`, which requires an unmodified buffer being handed to it. From this, I must specify `what` as an already created buffer, after which the width & height are assumed based on the line count of the buffer (which has nothing, and cannot be modified for my use case).

Introduces a simple option to just "don't change the sizes I passed", but not 100% sure of the implications of it.

I don't see anywhere else that these values are used further/modified, and `add_position_config` handles the case where they are passed as `nil`, etc.