### PR TITLE
feat: truncate strings from the middle

### DIFF
--- a/lua/plenary/strings.lua
+++ b/lua/plenary/strings.lua
@@ -120,18 +120,21 @@ local truncate = function(str, len, dots, direction)
   return result
 end
 
-M.truncate = function (str, len, dots, direction)
+M.truncate = function(str, len, dots, direction)
   str = tostring(str) -- We need to make sure its an actually a string and not a number
   dots = dots or "…"
   direction = direction or 1
   if direction ~= 0 then
     return truncate(str, len, dots, direction)
   else
-    local len1 = math.floor(len/2) + M.strdisplaywidth(dots)
+    if M.strdisplaywidth(str) <= len then
+      return str
+    end
+    local len1 = math.floor((len + M.strdisplaywidth(dots))/ 2)
     local len2 = len - len1 + M.strdisplaywidth(dots)
     local s1 = truncate(str, len1, dots, 1)
     local s2 = truncate(str, len2, dots, -1)
-    return s1 .. s2:sub(dots:len()+1)
+    return s1 .. s2:sub(dots:len() + 1)
   end
 end
 

--- a/lua/plenary/strings.lua
+++ b/lua/plenary/strings.lua
@@ -130,9 +130,9 @@ M.truncate = function(str, len, dots, direction)
     if M.strdisplaywidth(str) <= len then
       return str
     end
-    local len1 = math.floor((len + M.strdisplaywidth(dots))/ 2)
-    local len2 = len - len1 + M.strdisplaywidth(dots)
+    local len1 = math.floor((len + M.strdisplaywidth(dots)) / 2)
     local s1 = truncate(str, len1, dots, 1)
+    local len2 = len - M.strdisplaywidth(s1) + M.strdisplaywidth(dots)
     local s2 = truncate(str, len2, dots, -1)
     return s1 .. s2:sub(dots:len() + 1)
   end

--- a/lua/plenary/strings.lua
+++ b/lua/plenary/strings.lua
@@ -92,10 +92,7 @@ M.strcharpart = (function()
   end
 end)()
 
-M.truncate = function(str, len, dots, direction)
-  str = tostring(str) -- We need to make sure its an actually a string and not a number
-  dots = dots or "…"
-  direction = direction or 1
+local truncate = function(str, len, dots, direction)
   if M.strdisplaywidth(str) <= len then
     return str
   end
@@ -121,6 +118,21 @@ M.truncate = function(str, len, dots, direction)
     start = start + direction
   end
   return result
+end
+
+M.truncate = function (str, len, dots, direction)
+  str = tostring(str) -- We need to make sure its an actually a string and not a number
+  dots = dots or "…"
+  direction = direction or 1
+  if direction ~= 0 then
+    return truncate(str, len, dots, direction)
+  else
+    local len1 = math.floor(len/2) + M.strdisplaywidth(dots)
+    local len2 = len - len1 + M.strdisplaywidth(dots)
+    local s1 = truncate(str, len1, dots, 1)
+    local s2 = truncate(str, len2, dots, -1)
+    return s1 .. s2:sub(dots:len()+1)
+  end
 end
 
 M.align_str = function(string, width, right_justify)

--- a/tests/plenary/strings_spec.lua
+++ b/tests/plenary/strings_spec.lua
@@ -92,7 +92,7 @@ describe("strings", function()
       -- truncations from the middle
       { args = { "abcde", 6, nil, 0 }, expected = { single = "abcde", double = "abcde" } },
       { args = { "abcde", 5, nil, 0 }, expected = { single = "abcde", double = "abcde" } },
-      { args = { "abcde", 4, nil, 0 }, expected = { single = "ab…e", double = "a…e" } },
+      { args = { "abcde", 4, nil, 0 }, expected = { single = "a…de", double = "a…e" } },
       {
         args = { "アイウエオ", 11, nil, 0 },
         expected = { single = "アイウエオ", double = "アイウエオ" },
@@ -103,15 +103,15 @@ describe("strings", function()
       },
       {
         args = { "アイウエオ", 9, nil, 0 },
-        expected = { single = "アイ…エオ", double = "アイ…オ" },
+        expected = { single = "アイ…エオ", double = "ア…エオ" },
       },
-      { args = { "アイウエオ", 8, nil, 0 }, expected = { single = "アイ…オ", double =  "アイ…オ" } },
+      { args = { "アイウエオ", 8, nil, 0 }, expected = { single = "ア…エオ", double = "ア…エオ" } },
       { args = { "├─┤", 7, nil, 0 }, expected = { single = "├─┤", double = "├─┤" } },
       { args = { "├─┤", 6, nil, 0 }, expected = { single = "├─┤", double = "├─┤" } },
-      { args = { "├─┤", 5, nil, 0 }, expected = { single = "├─┤", double = "├…" } },
-      { args = { "├─┤", 4, nil, 0 }, expected = { single = "├─┤", double = "├…" } },
+      { args = { "├─┤", 5, nil, 0 }, expected = { single = "├─┤", double = "…┤" } },
+      { args = { "├─┤", 4, nil, 0 }, expected = { single = "├─┤", double = "…┤" } },
       { args = { "├─┤", 3, nil, 0 }, expected = { single = "├─┤", double = "…" } },
-      { args = { "├─┤", 2, nil, 0 }, expected = { single = "├…", double = "…" } },
+      { args = { "├─┤", 2, nil, 0 }, expected = { single = "…┤", double = "…" } },
     } do
       for _, ambiwidth in ipairs { "single", "double" } do
         local msg = ("ambiwidth = %s, direction = %s, [%s, %d] -> %s"):format(

--- a/tests/plenary/strings_spec.lua
+++ b/tests/plenary/strings_spec.lua
@@ -116,7 +116,7 @@ describe("strings", function()
       for _, ambiwidth in ipairs { "single", "double" } do
         local msg = ("ambiwidth = %s, direction = %s, [%s, %d] -> %s"):format(
           ambiwidth,
-          (case.args[4] > 0) and "right" or "left",
+          (case.args[4] > 0) and "right" or (case.args[4] < 0) and "left" or "middle",
           case.args[1],
           case.args[2],
           case.expected[ambiwidth]

--- a/tests/plenary/strings_spec.lua
+++ b/tests/plenary/strings_spec.lua
@@ -71,11 +71,11 @@ describe("strings", function()
       { args = { "abcde", 5, nil, -1 }, expected = { single = "abcde", double = "abcde" } },
       { args = { "abcde", 4, nil, -1 }, expected = { single = "…cde", double = "…de" } },
       {
-        args = { "アイウエオ", 11, nil, 1 },
+        args = { "アイウエオ", 11, nil, -1 },
         expected = { single = "アイウエオ", double = "アイウエオ" },
       },
       {
-        args = { "アイウエオ", 10, nil, 1 },
+        args = { "アイウエオ", 10, nil, -1 },
         expected = { single = "アイウエオ", double = "アイウエオ" },
       },
       {
@@ -89,6 +89,29 @@ describe("strings", function()
       { args = { "├─┤", 4, nil, -1 }, expected = { single = "├─┤", double = "…┤" } },
       { args = { "├─┤", 3, nil, -1 }, expected = { single = "├─┤", double = "…" } },
       { args = { "├─┤", 2, nil, -1 }, expected = { single = "…┤", double = "…" } },
+      -- truncations from the middle
+      { args = { "abcde", 6, nil, 0 }, expected = { single = "abcde", double = "abcde" } },
+      { args = { "abcde", 5, nil, 0 }, expected = { single = "abcde", double = "abcde" } },
+      { args = { "abcde", 4, nil, 0 }, expected = { single = "ab…e", double = "a…e" } },
+      {
+        args = { "アイウエオ", 11, nil, 0 },
+        expected = { single = "アイウエオ", double = "アイウエオ" },
+      },
+      {
+        args = { "アイウエオ", 10, nil, 0 },
+        expected = { single = "アイウエオ", double = "アイウエオ" },
+      },
+      {
+        args = { "アイウエオ", 9, nil, 0 },
+        expected = { single = "アイ…エオ", double = "アイ…オ" },
+      },
+      { args = { "アイウエオ", 8, nil, 0 }, expected = { single = "アイ…オ", double =  "アイ…オ" } },
+      { args = { "├─┤", 7, nil, 0 }, expected = { single = "├─┤", double = "├─┤" } },
+      { args = { "├─┤", 6, nil, 0 }, expected = { single = "├─┤", double = "├─┤" } },
+      { args = { "├─┤", 5, nil, 0 }, expected = { single = "├─┤", double = "├…" } },
+      { args = { "├─┤", 4, nil, 0 }, expected = { single = "├─┤", double = "├…" } },
+      { args = { "├─┤", 3, nil, 0 }, expected = { single = "├─┤", double = "…" } },
+      { args = { "├─┤", 2, nil, 0 }, expected = { single = "├…", double = "…" } },
     } do
       for _, ambiwidth in ipairs { "single", "double" } do
         local msg = ("ambiwidth = %s, direction = %s, [%s, %d] -> %s"):format(


### PR DESCRIPTION
Thought it might be useful to truncate strings from the middle.

Currently a bit of a rushed draft, and just guessed what the new tests should be (haven't actually run them yet 😅).
I will have another look over it in the next few days.