### PR TITLE
fix: correct position of `titlehighlight` when top border disabled

### DIFF
--- a/lua/plenary/window/border.lua
+++ b/lua/plenary/window/border.lua
@@ -143,7 +143,7 @@ function Border._create_lines(content_win_id, content_win_options, border_win_op
           botright
         )
         for _, r in pairs(bot_ranges) do
-          table.insert(ranges, { content_win_options.height + 1, r[1], r[2] })
+          table.insert(ranges, { content_win_options.height + thickness.top, r[1], r[2] })
         end
         break
       end


### PR DESCRIPTION
Little fix