### PR TITLE
feat: add `border_zindex` option to `popup` and `zindex` option to `Border`

### DIFF
--- a/lua/plenary/popup/init.lua
+++ b/lua/plenary/popup/init.lua
@@ -378,6 +378,7 @@ function popup.create(what, vim_options)
 
   local border = nil
   if should_show_border then
+    border_options.zindex = vim_options.border_zindex
     border_options.focusable = vim_options.border_focusable
     border_options.highlight = vim_options.borderhighlight and string.format("Normal:%s", vim_options.borderhighlight)
     border_options.titlehighlight = vim_options.titlehighlight

--- a/lua/plenary/window/border.lua
+++ b/lua/plenary/window/border.lua
@@ -214,6 +214,10 @@ function Border:__align_calc_config(content_win_options, border_win_options)
 
   vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, self.contents)
 
+  local b_zindex = border_win_options.zindex or content_win_options.zindex and content_win_options.zindex - 1 or 49
+  b_zindex = math.max(b_zindex, 1)
+  b_zindex = math.min(b_zindex, 32000)
+
   local thickness = border_win_options.border_thickness
   local nvim_win_config = {
     anchor = content_win_options.anchor,
@@ -223,7 +227,7 @@ function Border:__align_calc_config(content_win_options, border_win_options)
     col = content_win_options.col - thickness.left,
     width = content_win_options.width + thickness.left + thickness.right,
     height = content_win_options.height + thickness.top + thickness.bot,
-    zindex = content_win_options.zindex or 50,
+    zindex = b_zindex,
     noautocmd = content_win_options.noautocmd,
     focusable = vim.F.if_nil(border_win_options.focusable, false),
   }


### PR DESCRIPTION
Also changes default zindex for border to be one less than that of the content

@DimitrisMilonopoulos does this fix your issue when using neovide?

Resolves nvim-telescope/telescope.nvim#1564