### PR TITLE
fix: path normalization works with esoteric usernames

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -349,9 +349,9 @@ function Path:normalize(cwd)
   -- Substitute home directory w/ "~"
   -- string.gsub is not useful here because usernames with dashes at the end
   -- will be seen as a regexp pattern rather than a raw string
-  start, end = string.find(self.filename, path.home, 1, true)
+  local start, finish = string.find(self.filename, path.home, 1, true)
   if start == 1 then
-    self.filename = "~" .. string.sub(self.filename, (end + 1), -1)
+    self.filename = "~" .. string.sub(self.filename, (finish + 1), -1)
   end
 
   return _normalize_path(self.filename, self._cwd)

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -347,8 +347,12 @@ function Path:normalize(cwd)
   self:make_relative(cwd)
 
   -- Substitute home directory w/ "~"
-  local removed_path_sep = path.home:gsub(path.sep .. "$", "")
-  self.filename = self.filename:gsub("^" .. removed_path_sep, "~", 1)
+  -- string.gsub is not useful here because usernames with dashes at the end
+  -- will be seen as a regexp pattern rather than a raw string
+  start, end = string.find(self.filename, path.home, 1, true)
+  if start == 1 then
+    self.filename = "~" .. string.sub(self.filename, (end + 1), -1)
+  end
 
   return _normalize_path(self.filename, self._cwd)
 end

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -351,10 +351,10 @@ function Path:normalize(cwd)
   -- will be seen as a regexp pattern rather than a raw string
   local start, finish = string.find(self.filename, path.home, 1, true)
   if start == 1 then
-    self.filename = "~" .. string.sub(self.filename, (finish + 1), -1)
+    self.filename = "~" .. path.sep .. string.sub(self.filename, (finish + 1), -1)
   end
 
-  return _normalize_path(self.filename, self._cwd)
+  return _normalize_path(clean(self.filename), self._cwd)
 end
 
 local function shorten_len(filename, len, exclude)

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -227,6 +227,14 @@ describe("Path", function()
       p._cwd = "/tmp/lua"
       assert.are.same("~/test_file", p:normalize())
     end)
+
+    it("handles usernames with a dash at the end", function()
+      local home = "/home/mattr-"
+      local p = Path:new { home, "test_file" }
+      p.path.home = home
+      p._cwd = "/tmp/lua"
+      assert.are.same("~/test_file", p:normalize())
+    end)
   end)
 
   describe(":shorten", function()

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -212,7 +212,7 @@ describe("Path", function()
       assert.are.same("/tmp/lua/plenary/path.lua", p:normalize())
     end)
 
-    it("can normalize ~ when file is within home directory (traling slash)", function()
+    it("can normalize ~ when file is within home directory (trailing slash)", function()
       local home = "/home/test/"
       local p = Path:new { home, "./test_file" }
       p.path.home = home


### PR DESCRIPTION
Usernames with dashes at the end are perfectly valid unix user names, but they're seen as a regular expression pattern in Lua. Switch to using string.find instead of string.gsub to avoid the pattern matching issue.

Further solves https://github.com/nvim-telescope/telescope.nvim/issues/1521 for me