### PR TITLE
Ensure opacity of popup floating window

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ Status: WIP
 
 See [popup documentation](./POPUP.md) for both progress tracking and implemented APIs.
 
+*For best results, such as increasing opacity of the floating window, put this in your nvim configuration*:
+```viml
+set termguicolors
+```
+
 ### plenary.window
 
 Window helper functions to wrap some of the more difficult cases. Particularly for floating windows.


### PR DESCRIPTION
In my terminal, test output from plenary was difficult to read due to lack of opacity. See https://github.com/nvim-lua/plenary.nvim/issues/294#issue-1085333451