### PR TITLE
fix(job): shutdown raises error

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -209,7 +209,7 @@ end
 
 --- Shutdown a job.
 function Job:shutdown(code, signal)
-  if not uv.is_active(self._shutdown_check) then
+  if self._shutdown_check and not uv.is_active(self._shutdown_check) then
     vim.wait(1000, function()
       return self:_pipes_are_closed(self) and self.is_shutdown
     end, 1, true)


### PR DESCRIPTION
`job:shutdown()` raises an error if called without a `_shutdown_check` running.
 From what I experienced that is basically always the case.
This just checks if `_shutdown_check` is nil before passing it to `vim.loop.is_active`