### PR TITLE
feat(async): vimscript function proxy

### DIFF
--- a/lua/plenary/async/fn.lua
+++ b/lua/plenary/async/fn.lua
@@ -1,0 +1,15 @@
+local util = require "plenary.async.util"
+
+return setmetatable({}, {
+  __index = function(_, k)
+    return function(...)
+      -- if we are in a fast event await the scheduler
+      if vim.in_fast_event() then
+        util.scheduler()
+      end
+
+      return vim.fn[k](...)
+    end
+  end,
+})
+

--- a/lua/plenary/async/init.lua
+++ b/lua/plenary/async/init.lua
@@ -8,6 +8,7 @@ local lookups = {
   util = "plenary.async.util",
   lsp = "plenary.async.lsp",
   api = "plenary.async.api",
+  fn = "plenary.async.fn",
   tests = "plenary.async.tests",
   control = "plenary.async.control",
 }


### PR DESCRIPTION
Following on from #293 this would be a great addition to the async lib. Not sure if I should be adding anything else, I just added the same object as the `vim.api` proxy object