### PR TITLE
fix: allow border title position change/retaining

### DIFF
--- a/lua/plenary/window/border.lua
+++ b/lua/plenary/window/border.lua
@@ -173,12 +173,18 @@ local set_title_highlights = function(bufnr, ranges, hl)
   end
 end
 
-function Border:change_title(new_title)
+function Border:change_title(new_title, pos)
   if self._border_win_options.title == new_title then
     return
   end
 
-  self._border_win_options.title = new_title
+  pos = pos or (self._border_win_options.title[1] and self._border_win_options.title[1].pos)
+  if pos == nil then
+    self._border_win_options.title = new_title
+  else
+    self._border_win_options.title = { { text = new_title, pos = pos } }
+  end
+
   self.contents, self.title_ranges = Border._create_lines(
     self.content_win_id,
     self.content_win_options,


### PR DESCRIPTION
Previously would reset the position `pos` to `N` later on in `Border._create_lines` when calling `Border:change_title`. 
```lua
  -- border_win_options.title should have be a list with entries of the
  -- form: { pos = foo, text = bar }.
  -- pos can take values in { "NW", "N", "NE", "SW", "S", "SE" }
  local titles = type(border_win_options.title) == "string" and { { pos = "N", text = border_win_options.title } }
    or border_win_options.title
    or {}
```

Was causing issues in certain `telescope.nvim` applications (https://github.com/nvim-telescope/telescope-file-browser.nvim/pull/41#issuecomment-1004262654) where a title with `pos = "S"` was disappearing since the `pos` was being overwritten upon a `change_title` call.

My change should enable the retaining of `pos` or the explicit changing of it.