### PR TITLE
fix(window): accessing potentially empty border title index

### DIFF
--- a/lua/plenary/window/border.lua
+++ b/lua/plenary/window/border.lua
@@ -178,7 +178,8 @@ function Border:change_title(new_title, pos)
     return
   end
 
-  pos = pos or (self._border_win_options.title[1] and self._border_win_options.title[1].pos)
+  pos = pos
+    or (self._border_win_options.title and self._border_win_options.title[1] and self._border_win_options.title[1].pos)
   if pos == nil then
     self._border_win_options.title = new_title
   else


### PR DESCRIPTION
Better conditional for checking title position.

Came up due to downstream issue with Telescope.nvim that appeared with [latest commit](https://github.com/nvim-lua/plenary.nvim/commit/6d54c198a785131532de77978523c5f1e429d1e6).

<img width="1741" alt="Screen Shot 2022-01-05 at 9 17 32 AM" src="https://user-images.githubusercontent.com/3721204/148260480-5c210293-8aba-447c-a4b8-b785874800f2.png">

