### PR TITLE
fix: prevent double slash in normalized paths

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -44,6 +44,11 @@ path.root = (function()
   end
 end)()
 
+-- remove trailing slash from homedir if any
+if path.home:sub(-1) == path.sep then
+  path.home = path.home:sub(1,-2)
+end
+
 path.S_IF = S_IF
 
 local band = function(reg, value)

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -219,7 +219,7 @@ describe("Path", function()
       local p = Path:new { home, "./test_file" }
       p.path.home = home
       p._cwd = "/tmp/lua"
-      assert.are.same("~//./test_file", p:normalize())
+      assert.are.same("~/./test_file", p:normalize())
     end)
   end)
 


### PR DESCRIPTION
There was a regression introduced in https://github.com/nvim-lua/plenary.nvim/pull/279 where normalized paths could end up with double slashes when replacing homedir with `~`.

This was done to handle the case where a homedir contained a trailing slash.

This change will update `path.home` to ensure it does not contain a trailing slash, which will work around the indiscriminate addition of a slash in all normalised paths containing the homedir