### PR TITLE
Path:absolute on windows returns double disk name part if path contains ..

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -99,8 +99,17 @@ local function _normalize_path(filename, cwd)
   local has = string.find(filename, path.sep .. "..", 1, true) or string.find(filename, ".." .. path.sep, 1, true)
 
   if has then
-    local parts = _split_by_separator(filename)
+    local is_abs = is_absolute(filename, path.sep)
+    local split_without_disk_name = function(filename_local)
+      local parts = _split_by_separator(filename_local)
+      -- Remove disk name part on Windows
+      if path.sep == "\\" and is_abs then
+        table.remove(parts, 1)
+      end
+      return parts
+    end
 
+    local parts = split_without_disk_name(filename)
     local idx = 1
     local initial_up_count = 0
 
@@ -121,7 +130,7 @@ local function _normalize_path(filename, cwd)
     until idx > #parts
 
     local prefix = ""
-    if is_absolute(filename, path.sep) or #_split_by_separator(cwd) == initial_up_count then
+    if is_abs or #split_without_disk_name(cwd) == initial_up_count then
       prefix = path.root(filename)
     end
 

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -78,7 +78,7 @@ end
 
 local is_absolute = function(filename, sep)
   if sep == "\\" then
-    return string.match(filename, "^[%a]:\\.*$")
+    return string.match(filename, "^[%a]:\\.*$") ~= nil
   end
   return string.sub(filename, 1, 1) == sep
 end


### PR DESCRIPTION
Steps to reproduce:
`nvim -u init.vim`

init.vim
```
set runtimepath^=plenary.nvim
lua require('b')
```
b.lua
```
local Path = require('plenary.path')

local path = Path:new('C:\\projects\\work\\appcore\\..\\build')
print('filename = ' .. path.filename)
print('absolute = ' .. path:absolute())
```

output
```
filename = C:\projects\work\appcore\..\build
absolute = C:\C:\projects\work\build
```

This happens because on Windows `_split_by_separator` returns one more element, which is a disk name. And function `_normalize_path`  is not ready for that.

I know that I could change `_split_by_separator` behavior, but I decided, what it works correctly and disk name (if present) should be returned.

Also I included fix for `is_absolute` function. I understand, that it might break some plugins, if they were depending on this strange behavior. But it seems unlikely.

I tried to add tests for `normalize` with `sep = "\\"`, but because `path.lua` code mostly ignores passed `sep` and uses local `path.sep`, I was unable to do so =(