### PR TITLE
fix curl check if body string is file - "Path not valid" error if body contains $

### DIFF
--- a/lua/plenary/curl.lua
+++ b/lua/plenary/curl.lua
@@ -182,10 +182,14 @@ end
 parse.request = function(opts)
   if opts.body then
     local b = opts.body
+    local silent_is_file = function()
+      local status, result = pcall(P.is_file, P.new(b))
+      return status and result
+    end
     opts.body = nil
     if type(b) == "table" then
       opts.data = b
-    elseif P.is_file(P.new(b)) then
+    elseif silent_is_file() then
       opts.in_file = b
     elseif type(b) == "string" then
       opts.raw_body = b


### PR DESCRIPTION
When doing curl request with body which contain `$` the error is encountered because `Path` tries to expand `$`:
```
Traceback: ...site/pack/packer/start/plenary.nvim/lua/plenary/path.lua:311: Path not valid
```

I would say this fixes also https://github.com/nvim-lua/plenary.nvim/issues/299.