### PR TITLE
fix: plenary.path normalize

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -88,6 +88,12 @@ local function _normalize_path(filename, cwd)
     return filename
   end
 
+  -- handles redundant `./` in the middle
+  local redundant = path.sep.."."..path.sep
+  if filename:match(redundant) then
+    filename = filename:gsub(redundant, path.sep)
+  end
+
   local out_file = filename
 
   local has = string.find(filename, path.sep .. "..", 1, true) or string.find(filename, ".." .. path.sep, 1, true)

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -89,7 +89,7 @@ local function _normalize_path(filename, cwd)
   end
 
   -- handles redundant `./` in the middle
-  local redundant = path.sep.."."..path.sep
+  local redundant = path.sep .. "." .. path.sep
   if filename:match(redundant) then
     filename = filename:gsub(redundant, path.sep)
   end

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -341,7 +341,8 @@ function Path:normalize(cwd)
   self:make_relative(cwd)
 
   -- Substitute home directory w/ "~"
-  self.filename = self.filename:gsub("^" .. path.home, "~" .. path.sep, 1)
+  local removed_path_sep = path.home:gsub(path.sep .. "$", "")
+  self.filename = self.filename:gsub("^" .. removed_path_sep, "~", 1)
 
   return _normalize_path(self.filename, self._cwd)
 end

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -211,7 +211,7 @@ describe("Path", function()
       local p = Path:new { home, "./test_file" }
       p.path.home = home
       p._cwd = "/tmp/lua"
-      assert.are.same("~/./test_file", p:normalize())
+      assert.are.same("~/test_file", p:normalize())
     end)
 
     it("can normalize ~ when file is within home directory (no trailing slash)", function()
@@ -219,7 +219,7 @@ describe("Path", function()
       local p = Path:new { home, "./test_file" }
       p.path.home = home
       p._cwd = "/tmp/lua"
-      assert.are.same("~//./test_file", p:normalize())
+      assert.are.same("~/test_file", p:normalize())
     end)
   end)
 


### PR DESCRIPTION
This aims to fix problems seen in #330.

1. double-slash at the front for tilde-subbed home paths
2. extra `./` in the middle of a path