### PR TITLE
fix (path:normalize): handle filenames with the same prefix as the home directory

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -349,7 +349,11 @@ function Path:normalize(cwd)
   -- Substitute home directory w/ "~"
   -- string.gsub is not useful here because usernames with dashes at the end
   -- will be seen as a regexp pattern rather than a raw string
-  local start, finish = string.find(self.filename, path.home, 1, true)
+  local home = path.home
+  if string.sub(path.home, -1) ~= path.sep then
+    home = home .. path.sep
+  end
+  local start, finish = string.find(self.filename, home, 1, true)
   if start == 1 then
     self.filename = "~" .. path.sep .. string.sub(self.filename, (finish + 1), -1)
   end

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -235,6 +235,12 @@ describe("Path", function()
       p._cwd = "/tmp/lua"
       assert.are.same("~/test_file", p:normalize())
     end)
+
+    it("handles filenames with the same prefix as the home directory", function()
+      local p = Path:new "/home/test.old/test_file"
+      p.path.home = "/home/test"
+      assert.are.same("/home/test.old/test_file", p:normalize())
+    end)
   end)
 
   describe(":shorten", function()


### PR DESCRIPTION
Scenario:

home: /home/foo
file: /home/foobar/baz.txt

normalize returned ~/bar/baz.txt instead of /home/foobar/baz.txt