### PR TITLE
feat: add clojure-dart filetype

### DIFF
--- a/data/plenary/filetypes/base.lua
+++ b/data/plenary/filetypes/base.lua
@@ -437,6 +437,7 @@ return {
     ['hic'] = [[clojure]],
     ['cljx'] = [[clojure]],
     ['cljs'] = [[clojure]],
+    ['cljd'] = [[clojure]],
     ['json'] = [[json]],
     ['cljc'] = [[clojure]],
     ['pfa'] = [[postscr]],


### PR DESCRIPTION
[ClojureDart](https://github.com/Tensegritics/ClojureDart) released several days ago. 
Found this repo in telescope docs:

```
  Note: if plenary does not recognize your filetype yet
  1) Please consider contributing to:
     $PLENARY_REPO/data/plenary/filetypes/builtin.lua
```
So making this pr.