### PR TITLE
fix: avoid recursion when copying folder to itself

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -548,6 +548,7 @@ function Path:copy(opts)
   end
   -- dir
   if opts.recursive then
+    local suffix = table.remove(self:_split())
     dest:mkdir {
       parents = F.if_nil(opts.parents, false, opts.parents),
       exists_ok = F.if_nil(opts.exists_ok, true, opts.exists_ok),
@@ -561,13 +562,16 @@ function Path:copy(opts)
     })
     for _, entry in ipairs(data) do
       local entry_path = Path:new(entry)
-      local suffix = table.remove(entry_path:_split())
-      local new_dest = dest:joinpath(suffix)
-      -- clear destination as it might be Path table otherwise failing w/ extend
-      opts.destination = nil
-      local new_opts = vim.tbl_deep_extend("force", opts, { destination = new_dest })
-      -- nil: not overriden if `override = false`
-      success[new_dest] = entry_path:copy(new_opts) or false
+      local entry_suffix = table.remove(entry_path:_split())
+      -- avoid repeated recursive copying if folder is copied into itself
+      if suffix ~= entry_suffix then
+        local new_dest = dest:joinpath(entry_suffix)
+        -- clear destination as it might be Path table otherwise failing w/ extend
+        opts.destination = nil
+        local new_opts = vim.tbl_deep_extend("force", opts, { destination = new_dest })
+        -- nil: not overriden if `override = false`
+        success[new_dest] = entry_path:copy(new_opts) or false
+      end
     end
     return success
   else


### PR DESCRIPTION
Came across this when testing https://github.com/nvim-telescope/telescope-file-browser.nvim/pull/118

`cp` will raise a message that a folder cannot copied into itself the second time around, but I think it's fine to not have a message here.

E: thinking again, this needs checking that there not yet exists a folder within the folder with the same name or something. Am on phone, will fix later