### PR TITLE
change path.is_file to return false instead of erroring out

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -682,7 +682,11 @@ function Path:parents()
 end
 
 function Path:is_file()
-  local stat = uv.fs_stat(self:expand())
+  local status, expanded = pcall(function() self:expand() end)
+  if status == false then
+    return false
+  end
+  local stat = uv.fs_stat(expanded)
   if stat then
     return stat.type == "file" and true or nil
   end


### PR DESCRIPTION
Context: when the body of a curl request contains a "$", the request errors out.

Upon tracing the code, the failure came from parse.request checking if the body is a file.
This then trigger Path:expand, which then error out because it wasn't a valid path.

The fix ensures that is_file never errors out on bad path and instead returns false instead.