### PR TITLE
feat: defer libuv calls in Path:new

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -171,9 +171,9 @@ Path.__index = function(t, k)
   end
 
   if k == "_absolute" then
-    local cwd = uv.fs_realpath(t.filename)
-    t._cwd = cwd
-    return cwd
+    local absolute = uv.fs_realpath(t.filename)
+    t._absolute = absolute
+    return absolute
   end
 end
 

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -158,7 +158,24 @@ local check_self = function(self)
   return self
 end
 
-Path.__index = Path
+Path.__index = function(t, k)
+  local raw = rawget(Path, k)
+  if raw then
+    return raw
+  end
+
+  if k == "_cwd" then
+    local cwd = uv.fs_realpath "."
+    t._cwd = cwd
+    return cwd
+  end
+
+  if k == "_absolute" then
+    local cwd = uv.fs_realpath(t.filename)
+    t._cwd = cwd
+    return cwd
+  end
+end
 
 -- TODO: Could use this to not have to call new... not sure
 -- Path.__call = Path:new
@@ -235,10 +252,6 @@ function Path:new(...)
     filename = path_string,
 
     _sep = sep,
-
-    -- Cached values
-    _absolute = uv.fs_realpath(path_string),
-    _cwd = uv.fs_realpath ".",
   }
 
   setmetatable(obj, Path)


### PR DESCRIPTION
Reduces `Path:new` to c. 1/3 of cost. Can be quite relevant for `telescope` finders that more greedily create `Path`s. Just thought I'd put this up for discussion.

```lua
local bench = require "plenary.benchmark"
local Path = require "plenary.path"

-- /home/fdschmidt/repos/lua/telescope-file-browser.nvim/
local filename = vim.api.nvim_buf_get_name(0)

bench("Path", {
  warmup = 10,
  runs = 50,
  fun = {
    {
      "Path creation",
      function()
        for _ = 1, 1000 do
          Path:new(filename)
        end
      end,
    },
  },
})
```

Before

Benchmark Group: 'Path' -----------------------                                                                                                                                                 
Benchmark 1: 'Path creation'                                                                                                                                                                   
  Time(mean ± σ):      9.2 ms ±   2.9 ms                                                                                                                                                        
  Range(min … max):    7.6 ms …  17.2 ms  50 runs

After

Benchmark Group: 'Path' -----------------------                                                                                                                                              
Benchmark 1: 'Path creation'                                                                                                                                                                
  Time(mean ± σ):      3.6 ms ±   1.0 ms                                                                                                                                                     
  Range(min … max):    3.0 ms …   7.8 ms  50 runs  

cc @miversen33