### PR TITLE
fix(test_harness): kill job on timeout and check signal for failure on job completion

### DIFF
--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -131,8 +131,8 @@ function harness.test_directory(directory, opts)
     if opts.sequential then
       log.debug("... Sequential wait for job number", i)
       Job.join(j, opts.timeout)
-      log.debug("... Completed job number", i)
-      if j.code ~= 0 then
+      log.debug("... Completed job number", i, j.code, j.signal)
+      if j.code ~= 0 or j.signal ~= 0 then
         failure = true
         if not opts.keep_going then
           break


### PR DESCRIPTION
This is to catch test runs where the process exits erroneously, for
example via a SIGABRT.

I also noticed that spawned jobs are not terminated should the test time out.