### PR TITLE
fix(log): no file made if no cache dir

### DIFF
--- a/lua/plenary/log.lua
+++ b/lua/plenary/log.lua
@@ -135,6 +135,10 @@ log.new = function(config, standalone)
 
     -- Output to log file
     if config.use_file then
+      local outfile_parent_path = require("plenary.path"):new(outfile):parent()
+      if not outfile_parent_path:exists() then
+        outfile_parent_path:mkdir { parent = true }
+      end
       local fp = assert(io.open(outfile, "a"))
       local str = string.format("[%-6s%s] %s: %s\n", nameupper, os.date(), lineinfo, msg)
       fp:write(str)


### PR DESCRIPTION
On Neovim nightly (currently pre `v0.8`), the log file cannot be created
and writen to since the `.cache/nvim` directory is not created. This is
fixed by checking that the parent of the outfile does not exist and if
it doesn't creating the directory, as mentioned by @Conni2461.

Fixes: GH-367
Signed-off-by: Filip Dutescu <filip.dutescu@gmail.com>