### PR TITLE
fix(job): remove freeze after shutdown is called

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -211,10 +211,9 @@ end
 
 --- Shutdown a job.
 function Job:shutdown(code, signal)
-  if self._shutdown_check and not uv.is_active(self._shutdown_check) then
-    vim.wait(1000, function()
-      return self:_pipes_are_closed(self) and self.is_shutdown
-    end, 1, true)
+  if self._shutdown_check and uv.is_active(self._shutdown_check) then
+    -- shutdown has already started
+    return
   end
 
   self:_shutdown(code, signal)

--- a/tests/plenary/job_spec.lua
+++ b/tests/plenary/job_spec.lua
@@ -10,6 +10,27 @@ local has_all_executables = function(execs)
   return true
 end
 
+local tables_equal = function(t1, t2)
+  if #t1 ~= #t2 then
+    return false
+  end
+  for i, t1_v in ipairs(t1) do
+    if t2[i] ~= t1_v then
+      return false
+    end
+  end
+  return true
+end
+
+local wait_for_result = function(job, result)
+  if type(result) == "string" then
+    result = { result }
+  end
+  vim.wait(1000, function()
+    return tables_equal(job:result(), result)
+  end)
+end
+
 describe("Job", function()
   describe("> cat manually >", function()
     it("should split simple stdin", function()
@@ -25,6 +46,8 @@ describe("Job", function()
       job:start()
       job:send "hello\n"
       job:send "world\n"
+
+      wait_for_result(job, { "hello", "world" })
       job:shutdown()
 
       assert.are.same(job:result(), { "hello", "world" })
@@ -46,6 +69,8 @@ describe("Job", function()
       job:send "\n"
       job:send "world\n"
       job:send "\n"
+
+      wait_for_result(job, { "hello", "", "world", "" })
       job:shutdown()
 
       assert.are.same(job:result(), { "hello", "", "world", "" })
@@ -66,6 +91,8 @@ describe("Job", function()
       job:start()
       job:send "hello\nwor"
       job:send "ld\n"
+
+      wait_for_result(job, { "hello", "world" })
       job:shutdown()
 
       assert.are.same(job:result(), { "hello", "world" })
@@ -655,6 +682,7 @@ describe("Job", function()
       input_pipe:write "job.lua\n"
       input_pipe:close()
 
+      wait_for_result(fzf, "job.lua")
       fzf:shutdown()
 
       local results = fzf:result()
@@ -692,6 +720,7 @@ describe("Job", function()
       input_pipe:write "job.lua"
       input_pipe:close()
 
+      wait_for_result(fzf, "job.lua")
       fzf:shutdown()
 
       local results = fzf:result()


### PR DESCRIPTION
### Context
I use both `plenary.popup` and `plenary.job` in my plugin [please.nvim](https://github.com/marcuscaisey/please.nvim) to [run a command in a popup terminal](https://github.com/marcuscaisey/please.nvim/blob/9a9068c75218372c4e962f364e3c8ee559c9d5d5/lua/please/runners/popup.lua#L49) and map `q` to close the popup / shutdown the job like this (simplified, [actual code here](https://github.com/marcuscaisey/please.nvim/blob/05d94392a18d8d094347100e7fcacb135701e422/lua/please/runners/popup.lua#L166-L184)):
```lua
vim.keymap.set('n', 'q', function()
  close_windows()
  job:shutdown()
end, { buffer = term_bufnr })
```

### Problem
The editor becomes unresponsive for a second after pressing `q` (and therefore calling `Job:shutdown`). Here's a minimal example which demonstrates this:
```lua
local Job = require 'plenary.job'
local job = Job:new {
  command = 'bash',
  args = { '-c', 'for i in $(seq 1 1000); do echo line $i && sleep 0.1; done' },
}

vim.keymap.set('n', 'q', function()
  job:shutdown()
end, { buffer = vim.api.nvim_get_current_buf() })

job:start()
``` 

If you `:so %` this and then `q`, you won't be able to move the cursor up and down for a second. This is because in `Job:shutdown` we wait for 1000ms, checking every 1ms, for `self:_pipes_are_closed(self) and self.is_shutdown` which never happens: https://github.com/nvim-lua/plenary.nvim/blob/4b66054e75356ac0b909bbfee9c682e703f535c2/lua/plenary/job.lua#L213-L221 

### Solution
Just remove the `vim.wait` call since i'm not sure what purpose it serves. Unless the command that you're running finishes in the time between the `Job:shutdown` call and 1s after that, `self:_pipes_are_closed(self) and self._is_shutdown` is always going to be `false` and so we're always going to wait / freeze for 1s. Please correct me if there is a function of the `vim.wait` that i'm missing 🙏 