### PR TITLE
fix(test_harness): retain failure status when running tests sequentially

### DIFF
--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -138,7 +138,7 @@ function harness.test_directory(directory, opts)
         end)
       else
         log.debug("... Completed job number", i, j.code, j.signal)
-        failure = j.code ~= 0 or j.signal ~= 0
+        failure = failure or j.code ~= 0 or j.signal ~= 0
       end
       if failure and not opts.keep_going then
         break


### PR DESCRIPTION
Currently, when running tests sequentially, the very last spec file that
executes will determine whether a failure has happened or not.
