### PR TITLE
Correct path.sep for POSIX LuaJIT consumers

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -21,7 +21,7 @@ path.home = vim.loop.os_homedir()
 path.sep = (function()
   if jit then
     local os = string.lower(jit.os)
-    if os == "linux" or os == "osx" or os == "bsd" then
+    if os ~= "windows" then
       return "/"
     else
       return "\\"


### PR DESCRIPTION
The existing path.sep logic tested explicitly for Linux, OSX, or BSD OSes as queried through LuaJIT (if present).  This left out other POSIX OSes, which will almost certainly use the UNIX-style forward slash, rather than backslash.

Since Windows is the odd one out when it comes to path separators, using it for the comparison should provide better coverage long-term.  If you'd prefer I simply add `posix` to the existing comparison list, I'm happy to update the PR.  I don't have a Windows machine to test one.