### PR TITLE
chore(luassert): bump to v1.9.0

### DIFF
--- a/lua/luassert/assert.lua
+++ b/lua/luassert/assert.lua
@@ -42,7 +42,7 @@ local __state_meta = {
       local arguments = util.make_arglist(...)
       local val, retargs = assertion.callback(self, arguments, util.errorlevel())
 
-      if not val == self.mod then
+      if (not val) == self.mod then
         local message = assertion.positive_message
         if not self.mod then
           message = assertion.negative_message

--- a/lua/luassert/assertions.lua
+++ b/lua/luassert/assertions.lua
@@ -238,7 +238,9 @@ local function error_matches(state, arguments, level)
   end
 
   -- err_actual must be (convertible to) a string
-  if util.hastostring(err_actual) then
+  if util.hastostring(err_actual) or
+     type(err_actual) == "number" or
+     type(err_actual) == "boolean" then
     err_actual = tostring(err_actual)
     retargs[1] = err_actual
   end

--- a/lua/luassert/languages/en.lua
+++ b/lua/luassert/languages/en.lua
@@ -34,11 +34,11 @@ s:set("assertion.called_at_most.positive", "Expected to be called at most %s tim
 s:set("assertion.called_more_than.positive", "Expected to be called more than %s time(s), but was called %s time(s)")
 s:set("assertion.called_less_than.positive", "Expected to be called less than %s time(s), but was called %s time(s)")
 
-s:set("assertion.called_with.positive", "Function was not called with the arguments")
-s:set("assertion.called_with.negative", "Function was called with the arguments")
+s:set("assertion.called_with.positive", "Function was never called with matching arguments.\nCalled with (last call if any):\n%s\nExpected:\n%s")
+s:set("assertion.called_with.negative", "Function was called with matching arguments at least once.\nCalled with (last matching call):\n%s\nDid not expect:\n%s")
 
-s:set("assertion.returned_with.positive", "Function was not returned with the arguments")
-s:set("assertion.returned_with.negative", "Function was returned with the arguments")
+s:set("assertion.returned_with.positive", "Function never returned matching arguments.\nReturned (last call if any):\n%s\nExpected:\n%s")
+s:set("assertion.returned_with.negative", "Function returned matching arguments at least once.\nReturned (last matching call):\n%s\nDid not expect:\n%s")
 
 s:set("assertion.returned_arguments.positive", "Expected to be called with %s argument(s), but was called with %s")
 s:set("assertion.returned_arguments.negative", "Expected not to be called with %s argument(s), but was called with %s")

--- a/lua/luassert/util.lua
+++ b/lua/luassert/util.lua
@@ -89,7 +89,7 @@ function util.deepcopy(t, deepmt, cache)
     copy[k] = (spy.is_spy(v) and v or util.deepcopy(v, deepmt, cache))
   end
   if deepmt then
-    debug.setmetatable(copy, util.deepcopy(debug.getmetatable(t, nil, cache)))
+    debug.setmetatable(copy, util.deepcopy(debug.getmetatable(t), false, cache))
   else
     debug.setmetatable(copy, debug.getmetatable(t))
   end
@@ -274,6 +274,7 @@ end
 function util.callable(object)
   return type(object) == "function" or type((debug.getmetatable(object) or {}).__call) == "function"
 end
+
 -----------------------------------------------
 -- Checks an element has tostring.
 -- The type must either be a string or have a metatable


### PR DESCRIPTION
I wanted to update `languages/en.lua` in order to properly fix #376, because last time language file was not updated in #377, but it's required. After this change it looks like this:

```
Fail    ||      plugin/format configure_format sets up format on save for matching client
            tests/nvim/unit/plugin/format_spec.lua:98: Function was never called with matching arguments.
            Called with (last call if any):
            (values list) ((string) 'BufWritePre', (table: 0x7f3b2e6bb060) {
              [buffer] = 1
              [callback] = function: 0x7f3b2e6b8798
              [desc] = 'Format on save'
              [group] = 3 })
            Expected:
            (values list) ((string) 'BufWritePre', (table: 0x7f3b2e6c5180) {
              [buffer] = 1
              [callback] = function: 0x7f3b2e6c5230
              [desc] = 'Format on save'
              [group] = 3 })
            
            stack traceback:
                tests/nvim/unit/plugin/format_spec.lua:98: in function 'assert_configure_format'
                tests/nvim/unit/plugin/format_spec.lua:237: in function <tests/nvim/unit/plugin/format_spec.lua:231>
```

While I'm at it I also updated luassert to latest version.