### PR TITLE
feat: Add file limit command for macOS to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,8 +391,9 @@ DELETED: Please use packer.nvim or other lua-rocks wrapper instead. This no long
 ### FAQ
 
 1. Error: Too many open files
+
 - \*nix systems have a setting to configure the maximum amount of open file
-  handles. It can occur that the default value is pretty low and that you end
-  up getting this error after opening a couple of files. You can see the
-  current limit with `ulimit -n` and set it with `ulimit -n 4096`. (macos might
-  work different)
+  handles. It can occur that the default value is pretty low and that you end up
+  getting this error after opening a couple of files. On Linux you can see the
+  current limit with `ulimit -n` and set it with `ulimit -n 4096`. If you're on
+  macOS the command is `sudo launchctl limit maxfiles 4096 4096`.


### PR DESCRIPTION
The README only showed the command to raise the limit on the number of open files (`ulimit`). I added the command for macOS (`sudo launchctl`), as it can be difficult to find. This is especially needed for macOS because the default limit hearkens back to the weak computers of yore and has never been updated so it's extremely low for modern computers.

My linter I have set up in null-ls also ran, which wrapped the Markdown to make it easier to read. If that's a problem I can try to change it back.