### PR TITLE
fix: allow $ in path expend when not part of an environment variable

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -331,7 +331,7 @@ function Path:expand()
     if val then
       expanded = string.gsub(string.gsub(self.filename, rep, val), "%$", "")
     else
-      expanded = nil
+      expanded = self.filename
     end
   else
     expanded = self.filename


### PR DESCRIPTION
This is far from perfect, as there is no way to differentiate between an intended $ and a failed attempt at using an environment variable. But this way it works with the former rather than throwing an error