### PR TITLE
ci: add luarocks upload release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: "release"
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: leafo/gh-actions-lua@v9
+      - uses: leafo/gh-actions-luarocks@v4
+      - name: Install dkjson
+        run: luarocks install dkjson
+      - name: Luarocks Upload
+        run: make luarocks_upload

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ test:
 
 generate_filetypes:
 	nvim --headless -c 'luafile scripts/update_filetypes_from_github.lua' -c 'qa!'
+
+luarocks_upload:
+	bash ./scripts/luarocks-upload.sh

--- a/scripts/luarocks-upload.sh
+++ b/scripts/luarocks-upload.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Expects the LUAROCKS_API_KEY secret to be set
+
+TMP_DIR=$(mktemp -d)
+MODREV=$(git describe --tags --always --first-parent | tr -d "v")
+DEST_ROCKSPEC="$TMP_DIR/plenary.nvim-$MODREV-1.rockspec"
+cp "plenary.nvim-scm-1.rockspec" "$DEST_ROCKSPEC"
+sed -i "s/'scm'/'$MODREV'/g" "$DEST_ROCKSPEC"
+luarocks upload "$DEST_ROCKSPEC" --api-key="$LUAROCKS_API_KEY"


### PR DESCRIPTION
@Conni2461

see https://github.com/nvim-telescope/telescope.nvim/pull/2276#issuecomment-1368446702.

The upload script expects a `LUAROCKS_API_KEY`. It should be possible to set it as one of this repo's GitHub Actions secrets.

I have tested `make luarocks_upload` and it seems to work, but I cannot test this with GitHub Actions. The lua/luarocks install tasks fail when run locally with [act](https://github.com/nektos/act), but maybe they will succeed on GitHub.