### PR TITLE
fix(luarocks-upload): make sure correct archive is uploaded

### DIFF
--- a/scripts/luarocks-upload.sh
+++ b/scripts/luarocks-upload.sh
@@ -6,5 +6,5 @@ TMP_DIR=$(mktemp -d)
 MODREV=$(git describe --tags --always --first-parent | tr -d "v")
 DEST_ROCKSPEC="$TMP_DIR/plenary.nvim-$MODREV-1.rockspec"
 cp "plenary.nvim-scm-1.rockspec" "$DEST_ROCKSPEC"
-sed -i "s/'scm'/'$MODREV'/g" "$DEST_ROCKSPEC"
+sed -i "s/= 'scm',/= '$MODREV',/g" "$DEST_ROCKSPEC"
 luarocks upload "$DEST_ROCKSPEC" --api-key="$LUAROCKS_API_KEY"


### PR DESCRIPTION
@Conni2461

the upload script's `sed` call replaces `'scm'` in the following section:
```lua
if _MODREV == 'scm' then
   source = {
      url = 'git://github.com/nvim-lua/plenary.nvim',
   }
end
```
This PR makes sure it only replaces the declaration at the top of the file:
```lua
local _MODREV, _SPECREV = 'scm', '-1'
```