### PR TITLE
feat: allow specifying the binary to launch neovim in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Where the first argument is the directory you'd like to test. It will search for
 the pattern `*_spec.lua` and execute them in separate neovim instances.
 
 The second argument is a Lua option table with the following fields:
+- `nvim_cmd`: specify the command to launch this neovim instance (defaults to `vim.v.progpath`)
 - `minimal_init`: specify an init.vim to use for this instance, uses `--noplugin`
 - `minimal`: uses `--noplugin` without an init script (overrides `minimal_init`)
 - `sequential`: whether to run tests sequentially (default is to run in parallel)

--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -41,6 +41,7 @@ end
 function harness.test_directory(directory, opts)
   print "Starting..."
   opts = vim.tbl_deep_extend("force", {
+    nvim_cmd = vim.v.progpath,
     winopts = { winblend = 3 },
     sequential = false,
     keep_going = true,
@@ -95,7 +96,7 @@ function harness.test_directory(directory, opts)
     end
 
     local job = Job:new {
-      command = vim.v.progpath,
+      command = opts.nvim_cmd,
       args = args,
 
       -- Can be turned on to debug


### PR DESCRIPTION
Use case: Run tests for neovim derivations packaged with Nix.

See also:
* https://github.com/NixOS/nixpkgs/issues/78033
* https://github.com/MrcJkb/haskell-tools.nvim/pull/93#issuecomment-1374969656