### PR TITLE
Fix PlenaryBustedDirectory command

### DIFF
--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -31,7 +31,7 @@ end
 
 function harness.test_directory_command(command)
   local split_string = vim.split(command, " ")
-  local directory = table.remove(split_string, 1)
+  local directory = vim.fn.expand(table.remove(split_string, 1))
 
   local opts = assert(loadstring("return " .. table.concat(split_string, " ")))()
 

--- a/plugin/plenary.vim
+++ b/plugin/plenary.vim
@@ -4,6 +4,6 @@ command! -nargs=1 -complete=file PlenaryBustedFile
       \ lua require('plenary.busted').run(vim.fn.expand("<args>"))
 
 command! -nargs=+ -complete=file PlenaryBustedDirectory
-      \ lua require('plenary.test_harness').test_directory_command(vim.fn.expand("<args>"))
+      \ lua require('plenary.test_harness').test_directory_command("<args>")
 
 nnoremap <Plug>PlenaryTestFile :lua require('plenary.test_harness').test_directory(vim.fn.expand("%:p"))<CR>


### PR DESCRIPTION
expand() should only be called for the first argument, not for the second one.
The second argument is a string representation of a Lua option table which did work in case of a single entry, where only the braces were removed.
For multiple entries Lua was not able to parse the expanded version as option table anymore, though.