### PR TITLE
feat: add dtsi filetype

### DIFF
--- a/data/plenary/filetypes/builtin.lua
+++ b/data/plenary/filetypes/builtin.lua
@@ -53,6 +53,7 @@ return {
     ['tscn'] = 'gdresource',
     ['tsx'] = 'typescriptreact',
     ['sol'] = 'solidity',
+    ['dtsi'] = 'dts',
   },
   file_name = {
     ['cakefile'] = 'coffee',


### PR DESCRIPTION
Add device tree extension mapping.
`.dts` are recognized fine but not `.dtsi`