### PR TITLE
feat(curl): add support for streaming responses

### DIFF
--- a/lua/plenary/curl.lua
+++ b/lua/plenary/curl.lua
@@ -251,10 +251,14 @@ local request = function(specs)
     return args
   end
 
-  local job = J:new {
+  local job_opts = {
     command = "curl",
     args = args,
-    on_exit = function(j, code)
+  }
+  if opts.stream then
+    job_opts.on_stdout = opts.stream
+  else
+    job_opts.on_exit = function(j, code)
       if code ~= 0 then
         error(
           string.format(
@@ -272,10 +276,11 @@ local request = function(specs)
       else
         response = output
       end
-    end,
-  }
+    end
+  end
+  local job = J:new(job_opts)
 
-  if opts.callback then
+  if opts.callback or opts.stream then
     return job:start()
   else
     job:sync(10000)


### PR DESCRIPTION
Add a new `stream` function option to specify that response data should be streamed to the `stream` function.

An example of this in use:

``` lua
curl.get("https://streaming-url/", {
  raw = { "--no-buffer" }, -- optional to indicate that curl shouldn't buffer output stream.  maybe always include this?
  stream = function(err, data, job)
    vim.pretty_print(data)
  end,
})
```

And of course the connection can be closed by calling `job:shutdown()`