### PR TITLE
fix(job): escape cwd path

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -65,7 +65,7 @@ local function expand(path)
     return assert(uv.fs_realpath(path), string.format("Path must be valid: %s", path))
   else
     -- TODO: Probably want to check that this is valid here... otherwise that's weird.
-    return vim.fn.expand(path, true)
+    return vim.fn.expand(vim.fn.escape(path, "$"), true)
   end
 end
 


### PR DESCRIPTION
Currently unable to use `Job` where `cwd` has a `$` symbol as it's being expanded out by `vim.fn.expand`.
This is causing an issue downstream with [telescope-file-browser](https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/244) when fetch git status info using cwd paths like `($lang)/` which is used in [Remix](https://remix.run/docs/en/1.15.0/file-conventions/route-files-v2#optional-segments).

Testing:
1. `mkdir "(\$foo)" && cd "(\$foo)"`
2. create a lua file and paste in 
```lua
require("plenary.job")
	:new({
		command = "ls",
		cwd = vim.loop.cwd(),
	})
	:sync()
```
3. `:w` followed by `so %` 

On `master` this will throw an error. 