### PR TITLE
Make is_uri accept all valid schemas

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -73,7 +73,7 @@ local _split_by_separator = (function()
 end)()
 
 local is_uri = function(filename)
-  return string.match(filename, "^%w+://") ~= nil
+  return string.match(filename, "^[%w+-.]://") ~= nil
 end
 
 local is_absolute = function(filename, sep)


### PR DESCRIPTION
A URI scheme can contain "-", "+" and "*" as well as digits and letters.

https://www.rfc-editor.org/rfc/rfc3986#page-17