### PR TITLE
feat(curl): return job instance if the request is stream or callback

### DIFF
--- a/lua/plenary/curl.lua
+++ b/lua/plenary/curl.lua
@@ -284,7 +284,8 @@ local request = function(specs)
   local job = J:new(job_opts)
 
   if opts.callback or opts.stream then
-    return job:start()
+    job:start()
+    return job
   else
     local timeout = opts.timeout or 10000
     job:sync(timeout)


### PR DESCRIPTION
Hey,
In some situations, when the request is a long stream request (`--no-buffer`), it might be handy to kill/shutdown the curl request (aka job). In this way, we can use the curl like:

```
	local handler
	handler = curl.post({
		url = "https://exampleai.fo/chat/completions",
		raw = { "--no-buffer" },
		headers = {
			content_type = "application/json",
		},
		body = vim.json.encode(data),
		stream = function(_, chunk)
		  vim.print(chunk)
		end,
		on_error = function(err, _, _)
			return on_complete(err, nil)
		end,
	})
	
	-- keymap <C-x> shutdown the long/unneeded stream
       handler:shutdown()

```