### PR TITLE
feat(log): allow arbitrary logging file paths

### DIFF
--- a/lua/plenary/log.lua
+++ b/lua/plenary/log.lua
@@ -13,26 +13,31 @@ end
 
 -- User configuration section
 local default_config = {
-  -- Name of the plugin. Prepended to log messages
+  -- Name of the plugin. Prepended to log messages.
   plugin = "plenary",
 
-  -- Should print the output to neovim while running
+  -- Should print the output to neovim while running.
   -- values: 'sync','async',false
   use_console = "async",
 
-  -- Should highlighting be used in console (using echohl)
+  -- Should highlighting be used in console (using echohl).
   highlights = true,
 
-  -- Should write to a file
+  -- Should write to a file.
+  -- Default output for logging file is `stdpath("cache")/plugin`.
   use_file = true,
 
-  -- Should write to the quickfix list
+  -- Output file has precedence over plugin, if not nil.
+  -- Used for the logging file, if not nil and use_file == true.
+  outfile = nil,
+
+  -- Should write to the quickfix list.
   use_quickfix = false,
 
   -- Any messages above this level will be logged.
   level = p_debug and "debug" or "info",
 
-  -- Level configuration
+  -- Level configuration.
   modes = {
     { name = "trace", hl = "Comment" },
     { name = "debug", hl = "Comment" },
@@ -42,7 +47,7 @@ local default_config = {
     { name = "fatal", hl = "ErrorMsg" },
   },
 
-  -- Can limit the number of decimals displayed for floats
+  -- Can limit the number of decimals displayed for floats.
   float_precision = 0.01,
 }
 
@@ -54,7 +59,10 @@ local unpack = unpack or table.unpack
 log.new = function(config, standalone)
   config = vim.tbl_deep_extend("force", default_config, config)
 
-  local outfile = string.format("%s/%s.log", vim.api.nvim_call_function("stdpath", { "cache" }), config.plugin)
+  local outfile = vim.F.if_nil(
+    config.outfile,
+    string.format("%s/%s.log", vim.api.nvim_call_function("stdpath", { "cache" }), config.plugin)
+  )
 
   local obj
   if standalone then


### PR DESCRIPTION
Justification: Allow write logs into directory `stdpath(data)` like lsp and telescope or VimBeGood.