### PR TITLE
fix(filtetype.lua): don't fail on integer filepath

### DIFF
--- a/lua/plenary/filetype.lua
+++ b/lua/plenary/filetype.lua
@@ -160,6 +160,10 @@ filetype.detect = function(filepath, opts)
   opts = opts or {}
   opts.fs_access = opts.fs_access or true
 
+  if type(filepath) ~= string then
+    filepath = tostring(filepath)
+  end
+
   local match = filetype.detect_from_name(filepath)
   if match ~= "" then
     return match


### PR DESCRIPTION
This looks to be very similar to #465

I have been encountering the below error when the filepath is an integer.

```
Error executing vim.schedule lua callback: ...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:428: Error executing lua: ...al/share/nvim/lazy/plenary.nvim/lua/plenary/filetype.lua:123: attempt to index local 'filepath' (a number value)
stack traceback:
	...al/share/nvim/lazy/plenary.nvim/lua/plenary/filetype.lua:123: in function 'detect_from_name'
	...al/share/nvim/lazy/plenary.nvim/lua/plenary/filetype.lua:167: in function 'detect'
	...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:434: in function <...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:428>
	[C]: in function 'nvim_buf_call'
	...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:428: in function <...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:422>
stack traceback:
	[C]: in function 'nvim_buf_call'
	...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:428: in function <...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:422>
```