### PR TITLE
fix: is_uri not accept all valid schemas

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -73,7 +73,7 @@ local _split_by_separator = (function()
 end)()
 
 local is_uri = function(filename)
-  return string.match(filename, "^[%w+-.]://") ~= nil
+  return string.match(filename, "^%w+[%w\\+\\-\\.]*://") ~= nil
 end
 
 local is_absolute = function(filename, sep)

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -73,7 +73,7 @@ local _split_by_separator = (function()
 end)()
 
 local is_uri = function(filename)
-  return string.match(filename, "^%w+[%w\\+\\-\\.]*://") ~= nil
+  return string.match(filename, "^%a[%w+-.]*://") ~= nil
 end
 
 local is_absolute = function(filename, sep)


### PR DESCRIPTION
According to #481 , and https://www.rfc-editor.org/rfc/rfc3986#page-17,

>Scheme names consist of a sequence of characters beginning with a
>letter and followed by any combination of letters, digits, plus
>("+"), period ("."), or hyphen ("-").

#481 not actually fix it, and caused other problems like is_uri not accept `jdt://` uri. this PR is a patch of it.