### PR TITLE
fix: ensure that handlers are emptied after notify_all

### DIFF
--- a/lua/plenary/async/control.lua
+++ b/lua/plenary/async/control.lua
@@ -32,10 +32,10 @@ function Condvar:notify_all()
     callback()
   end
 
-  for i = 1, len do
+  for _ = 1, len do
     -- table.remove will ensure that indexes are correct and make "ipairs" safe,
     -- which is not the case for "self.handles[i] = nil"
-    table.remove(self.handles, i)
+    table.remove(self.handles)
   end
 end
 

--- a/tests/plenary/async/condvar_spec.lua
+++ b/tests/plenary/async/condvar_spec.lua
@@ -125,4 +125,34 @@ describe("condvar", function()
 
     eq(3, counter)
   end)
+
+  a.it("notify all works multiple times", function()
+    local condvar = Condvar.new()
+    local counter = 0
+
+    a.run(function()
+      condvar:wait()
+      counter = counter + 1
+    end)
+
+    a.run(function()
+      condvar:wait()
+      counter = counter + 1
+    end)
+
+    eq(0, counter)
+
+    condvar:notify_all()
+
+    eq(2, counter)
+
+    a.run(function()
+      condvar:wait()
+      counter = 0
+    end)
+
+    condvar:notify_all()
+
+    eq(0, counter)
+  end)
 end)


### PR DESCRIPTION
Hi guys, I found that the condvar break in the following logic

```lua
local condvar = async.control.Condvar.new()

async.run(function()
    condvar:wait()
end)

async.run(function()
    condvar:wait()
end)

condvar:notify_all()

async.run(function()
    condvar:wait()
end)

-- break: The coroutine failed with this message: cannot resume dead coroutine
condvar:notify_all()
```

After some deeper research, I found that notify_all uses an index to empty the table inside the loop, but misses some elements due to index changed.