### PR TITLE
chore(busted): add spec and test as aliases for it

### DIFF
--- a/lua/plenary/async/init.lua
+++ b/lua/plenary/async/init.lua
@@ -33,6 +33,8 @@ exports.tests.add_globals = function()
   a.describe = exports.tests.describe
   -- must prefix with a or stack overflow
   a.it = exports.tests.it
+  a.spec = exports.tests.it
+  a.test = exports.tests.it
   a.pending = exports.tests.pending
   a.before_each = exports.tests.before_each
   a.after_each = exports.tests.after_each
@@ -47,6 +49,8 @@ exports.tests.add_to_env = function()
   env.a.describe = exports.tests.describe
   -- must prefix with a or stack overflow
   env.a.it = exports.tests.it
+  env.a.spec = exports.tests.it
+  env.a.test = exports.tests.it
   env.a.pending = exports.tests.pending
   env.a.before_each = exports.tests.before_each
   env.a.after_each = exports.tests.after_each

--- a/lua/plenary/async_lib/init.lua
+++ b/lua/plenary/async_lib/init.lua
@@ -20,6 +20,8 @@ exports.tests.add_globals = function()
   a.describe = exports.tests.describe
   -- must prefix with a or stack overflow
   a.it = exports.tests.it
+  a.spec = exports.tests.it
+  a.test = exports.tests.it
 end
 
 exports.tests.add_to_env = function()
@@ -34,6 +36,8 @@ exports.tests.add_to_env = function()
   env.a.describe = exports.tests.describe
   -- must prefix with a or stack overflow
   env.a.it = exports.tests.it
+  env.a.spec = exports.tests.it
+  env.a.test = exports.tests.it
 
   setfenv(2, env)
 end

--- a/lua/plenary/busted.lua
+++ b/lua/plenary/busted.lua
@@ -208,6 +208,8 @@ _PlenaryBustedOldAssert = _PlenaryBustedOldAssert or assert
 
 describe = mod.describe
 it = mod.it
+spec = mod.it
+test = mod.it
 pending = mod.pending
 before_each = mod.before_each
 after_each = mod.after_each

--- a/tests/plenary/simple_busted_spec.lua
+++ b/tests/plenary/simple_busted_spec.lua
@@ -19,6 +19,14 @@ describe("busted specs", function()
     pcall(tester_function)
   end)
 
+  test("should alias test as it", function()
+    assert(true)
+  end)
+
+  test("should alias spec as it", function()
+    assert(true)
+  end)
+
   pending("other thing pending", function()
     error()
   end)


### PR DESCRIPTION
this may be an unpopular opinion, but I prefer to use the `test` alias when writing my test functions. since it's something that is supported in [busted](https://lunarmodules.github.io/busted/) (see the section `It: Defining Tests`) I thought I'd expose it here too.

In my own testing, it didn't seem like it was required to export the functions in `async/init.lua` or `async_lib/init.lua`, but since all the other busted functions were also exported there, I added them.