### PR TITLE
feat(curl): use `XDG_RUNTIME_DIR` if available

### DIFF
--- a/lua/plenary/curl.lua
+++ b/lua/plenary/curl.lua
@@ -74,7 +74,8 @@ util.gen_dump_path = function()
   if P.path.sep == "\\" then
     path = string.format("%s\\AppData\\Local\\Temp\\plenary_curl_%s.headers", os.getenv "USERPROFILE", id)
   else
-    path = "/tmp/plenary_curl_" .. id .. ".headers"
+    local temp_dir = os.getenv "XDG_RUNTIME_DIR" or "/tmp"
+    path = temp_dir .. "/plenary_curl_" .. id .. ".headers"
   end
   return { "-D", path }
 end


### PR DESCRIPTION
I was using plenary.nvim on a non-major operating system (Android in case you wanna know) where `/temp` isn’t accessible. I believe many people who uses nvim on Android will find this useful. Also, there’s no android specific code. So hope it won’t hurt getting merged.