### PR TITLE
fix(path): Windows parent root directory

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -690,7 +690,7 @@ local _get_parent = (function()
   return function(abs_path)
     local parent = abs_path:match(formatted)
     if parent ~= nil and not parent:find(path.sep) then
-      return nil
+      return parent .. path.sep
     end
     return parent
   end

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -688,7 +688,11 @@ end
 local _get_parent = (function()
   local formatted = string.format("^(.+)%s[^%s]+", path.sep, path.sep)
   return function(abs_path)
-    return abs_path:match(formatted)
+    local parent = abs_path:match(formatted)
+    if parent ~= nil and not parent:find(path.sep) then
+      return nil
+    end
+    return parent
   end
 end)()
 


### PR DESCRIPTION
In Windows, doing `Path:new("C:\\Users"):parents()` results in a getting `C:` as one of its parents which is not a valid path. All valid paths in Windows, Linux, Mac must have at least one path separator.

Partially fixes https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/285