### PR TITLE
fix(path): make find_upwards() search root

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -931,10 +931,13 @@ function Path:find_upwards(filename)
   local folder = Path:new(self)
   local root = path.root(folder:absolute())
 
-  while folder:absolute() ~= root do
+  while true do
     local p = folder:joinpath(filename)
     if p:exists() then
       return p
+    end
+    if folder:absolute() == root then
+      break
     end
     folder = folder:parent()
   end

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -721,6 +721,34 @@ SOFTWARE.]]
       assert.are.same(should, data)
     end)
   end)
+
+  describe(":find_upwards", function()
+    it("finds files that exist", function()
+      local p = Path:new(debug.getinfo(1, "S").source:sub(2))
+      local found = p:find_upwards "README.md"
+      assert.are.same(found:absolute(), Path:new("README.md"):absolute())
+    end)
+
+    it("finds files that exist at the root", function()
+      local p = Path:new(debug.getinfo(1, "S").source:sub(2))
+
+      -- Temporarily set path.root to the root of this repository
+      local root = p.path.root
+      p.path.root = function(_)
+        return p:parent():parent():parent().filename
+      end
+
+      local found = p:find_upwards "README.md"
+      assert.are.same(found:absolute(), Path:new("README.md"):absolute())
+      p.path.root = root
+    end)
+
+    it("returns nil if no file is found", function()
+      local p = Path:new(debug.getinfo(1, "S").source:sub(2))
+      local found = p:find_upwards "MISSINGNO.md"
+      assert.are.same(found, nil)
+    end)
+  end)
 end)
 
 -- function TestPath:testIsDir()


### PR DESCRIPTION
~~The prior implementation had several implementation issues which caused an infinite loop if the search turned up empty.~~

This new implementation corrects the bounds check to stop searching once we've searched everywhere we can, and properly searches the root directory.