### PR TITLE
fix(job): escape square brackets `[]` from being expanded

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -65,7 +65,7 @@ local function expand(path)
     return assert(uv.fs_realpath(path), string.format("Path must be valid: %s", path))
   else
     -- TODO: Probably want to check that this is valid here... otherwise that's weird.
-    return vim.fn.expand(vim.fn.escape(path, "$"), true)
+    return vim.fn.expand(vim.fn.escape(path, "[]$"), true)
   end
 end
 


### PR DESCRIPTION
Looks like vim is doing regex string parsing when using `expand` so when using have paths that represent some invalid regex, an error is thrown.

In this particular case, the invalid regex came in the form of reverse range: `:expand("[z-a]")` will error out.


partially fixes https://github.com/nvim-telescope/telescope-file-browser.nvim/issues/289