### PR TITLE
fix: support LuaJIT versions with neovim 0.10.x and 0.9.2

### DIFF
--- a/lua/plenary/profile/p.lua
+++ b/lua/plenary/profile/p.lua
@@ -41,7 +41,7 @@
 
 -- Cache some library functions and objects.
 local jit = require("jit")
-assert(jit.version_num == 20100, "LuaJIT core/library version mismatch")
+assert(20100 <= jit.version_num and jit.version_num <= 20199, "LuaJIT core/library version mismatch: " .. jit.version)
 local profile = require("jit.profile")
 local vmdef = require("jit.vmdef")
 local math = math


### PR DESCRIPTION
neovim 0.10 has bumped up LuaJIT version, which makes plenary.profile
fail to work due to the "LuaJIT core/library version mismatch" error.
We can have an allowed range for `jit.version_num` as 20100~20199.

FYI, `require('jit')` reports:

  nvim-0.9.1:
    version = "LuaJIT 2.1.0-beta3",
    version_num = 20100

  nvim-0.10.x (HEAD version as of today, an example):
    version = "LuaJIT 2.1.1693268511",
    version_num = 20199
