### PR TITLE
Resolved invalid escape sequence error caused by Windows backslash in filepaths.

### DIFF
--- a/lua/plenary/busted.lua
+++ b/lua/plenary/busted.lua
@@ -215,6 +215,8 @@ clear = mod.clear
 assert = require "luassert"
 
 mod.run = function(file)
+  file = file:gsub("\\", "/")
+
   print("\n" .. HEADER)
   print("Testing: ", file)
 

--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -42,6 +42,7 @@ end
 
 function harness.test_directory(directory, opts)
   print "Starting..."
+  directory = directory:gsub("\\", "/")
   local minimal = not opts or not opts.init or opts.minimal or opts.minimal_init
 
   opts = vim.tbl_deep_extend("force", {

--- a/plugin/plenary.vim
+++ b/plugin/plenary.vim
@@ -1,9 +1,9 @@
 
 " Create command for running busted
 command! -nargs=1 -complete=file PlenaryBustedFile
-      \ lua require('plenary.busted').run(vim.fn.expand("<args>"))
+      \ lua require('plenary.busted').run(vim.fn.expand([[<args>]]))
 
 command! -nargs=+ -complete=file PlenaryBustedDirectory
-      \ lua require('plenary.test_harness').test_directory_command("<args>")
+      \ lua require('plenary.test_harness').test_directory_command([[<args>]])
 
 nnoremap <Plug>PlenaryTestFile :lua require('plenary.test_harness').test_directory(vim.fn.expand("%:p"))<CR>


### PR DESCRIPTION
This bug where Windows file paths that contain backslashes trigger an invalid escape sequence error was reported in issue #480.

This PR provides a solution for this escape sequence issue by:
- Changing the args string in plugin/plenary.vim to be a raw Lua string instead of using quotes like a regular string
- Performing a gsub to replace all backslashes with forward slashes in the functions called by the Plenary commands where the result of `vim.fn.expand` is passed as an argument (i.e. `plenary.busted.run` and `plenary.test_harness.test_directory`.