### PR TITLE
Fix for Plenary test harness floating results Window

### DIFF
--- a/lua/plenary/busted.lua
+++ b/lua/plenary/busted.lua
@@ -215,6 +215,8 @@ clear = mod.clear
 assert = require "luassert"
 
 mod.run = function(file)
+  file = file:gsub("\\", "/")
+
   print("\n" .. HEADER)
   print("Testing: ", file)
 

--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -103,7 +103,8 @@ function harness.test_directory(directory, opts)
     end
 
     table.insert(args, "-c")
-    table.insert(args, string.format('lua require("plenary.busted").run("%s")', p:absolute():gsub("\\", "\\\\")))
+    local abs_path = Path:new(directory, p.filename):absolute()
+    table.insert(args, string.format('lua require("plenary.busted").run("%s")', abs_path:gsub("\\", "\\\\")))
 
     local job = Job:new {
       command = opts.nvim_cmd,

--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -40,7 +40,7 @@ function harness.test_directory_command(command)
   return harness.test_directory(directory, opts)
 end
 
-local function _test_paths(paths, opts)
+local function test_paths(paths, opts)
   local minimal = not opts or not opts.init or opts.minimal or opts.minimal_init
 
   opts = vim.tbl_deep_extend("force", {
@@ -183,19 +183,18 @@ function harness.test_directory(directory, opts)
   directory = directory:gsub("\\", "/")
   local paths = harness._find_files_to_run(directory)
 
-  if vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1 then -- Paths work strangely on Windows
-    local abs_paths = vim.tbl_map(function(p)
+  -- Paths work strangely on Windows, so lets have abs paths
+  if vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1 then
+    paths = vim.tbl_map(function(p)
       return Path:new(directory, p.filename)
     end, paths)
-    _test_paths(abs_paths, opts)
-  else
-    _test_paths(paths, opts)
   end
+
+  test_paths(paths, opts)
 end
 
 function harness.test_file(filepath)
-  local fp = Path:new(filepath)
-  _test_paths { fp }
+  test_paths { Path:new(filepath) }
 end
 
 function harness._find_files_to_run(directory)

--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -182,10 +182,15 @@ function harness.test_directory(directory, opts)
   print "Starting..."
   directory = directory:gsub("\\", "/")
   local paths = harness._find_files_to_run(directory)
-  local abs_paths = vim.tbl_map(function(p)
-    return Path:new(directory, p.filename)
-  end, paths)
-  _test_paths(abs_paths, opts)
+
+  if vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1 then -- Paths work strangely on Windows
+    local abs_paths = vim.tbl_map(function(p)
+      return Path:new(directory, p.filename)
+    end, paths)
+    _test_paths(abs_paths, opts)
+  else
+    _test_paths(paths, opts)
+  end
 end
 
 function harness.test_file(filepath)

--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -42,6 +42,7 @@ end
 
 function harness.test_directory(directory, opts)
   print "Starting..."
+  directory = directory:gsub("\\", "/")
   local minimal = not opts or not opts.init or opts.minimal or opts.minimal_init
 
   opts = vim.tbl_deep_extend("force", {

--- a/plugin/plenary.vim
+++ b/plugin/plenary.vim
@@ -1,9 +1,9 @@
 
 " Create command for running busted
 command! -nargs=1 -complete=file PlenaryBustedFile
-      \ lua require('plenary.busted').run(vim.fn.expand([[<args>]]))
+      \ lua require('plenary.test_harness').test_file([[<args>]])
 
 command! -nargs=+ -complete=file PlenaryBustedDirectory
       \ lua require('plenary.test_harness').test_directory_command([[<args>]])
 
-nnoremap <Plug>PlenaryTestFile :lua require('plenary.busted').run(vim.fn.expand("%:p"))<CR>
+nnoremap <Plug>PlenaryTestFile :lua require('plenary.test_harness').test_file(vim.fn.expand("%:p"))<CR>

--- a/plugin/plenary.vim
+++ b/plugin/plenary.vim
@@ -1,9 +1,9 @@
 
 " Create command for running busted
 command! -nargs=1 -complete=file PlenaryBustedFile
-      \ lua require('plenary.busted').run(vim.fn.expand("<args>"))
+      \ lua require('plenary.busted').run(vim.fn.expand([[<args>]]))
 
 command! -nargs=+ -complete=file PlenaryBustedDirectory
-      \ lua require('plenary.test_harness').test_directory_command("<args>")
+      \ lua require('plenary.test_harness').test_directory_command([[<args>]])
 
 nnoremap <Plug>PlenaryTestFile :lua require('plenary.test_harness').test_directory(vim.fn.expand("%:p"))<CR>

--- a/plugin/plenary.vim
+++ b/plugin/plenary.vim
@@ -6,4 +6,4 @@ command! -nargs=1 -complete=file PlenaryBustedFile
 command! -nargs=+ -complete=file PlenaryBustedDirectory
       \ lua require('plenary.test_harness').test_directory_command([[<args>]])
 
-nnoremap <Plug>PlenaryTestFile :lua require('plenary.test_harness').test_directory(vim.fn.expand("%:p"))<CR>
+nnoremap <Plug>PlenaryTestFile :lua require('plenary.busted').run(vim.fn.expand("%:p"))<CR>


### PR DESCRIPTION
According to issue #480, the `PlenaryBustedDirectory` and `PlenaryBustedFile` commands cause a visual bug because they are being run as if they are in headless mode, although they are not. 

This PR refactors thetesting and floating window logic out into a separate internal function, `_test_paths`, which tests the paths it is provided according to the `opts` it's passed and displays the results via stdout or a floating window depending on whether or not Neovim is being run headlessly.

Additionally, users would rely on the keymap `<Plug>PlenaryTestFile` to run tests from within a Neovim instance. This is supposed to display test file results in a floating window, but this would also cause a visual glitch due to using the `plenary.busted.run` command directly, instead of being scheduled by `plenary.test_harness` and getting displayed in a floating window.

This PR fixes that by changing the usage of `plenary.busted.run` to use a newly created command,
`plenary.test_harness.test_file`, which tests only a single lua file and displays the results in either stdout or a floating window (according to whether or not Neovim is being run headlessly).