### PR TITLE
fix: timeout error on Windows using powershell when testing dirs

### DIFF
--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -187,9 +187,10 @@ function harness._find_files_to_run(directory)
   local finder
   if vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1 then
     -- On windows use powershell Get-ChildItem instead
+    local cmd = vim.fn.executable("pwsh.exe") == 1 and "pwsh" or "powershell"
     finder = Job:new {
-      command = "powershell",
-      args = { "-Command", [[Get-ChildItem -Recurse -n -Filter "*_spec.lua"]] },
+      command = cmd,
+      args = { "-NoProfile", "-Command", [[Get-ChildItem -Recurse -n -Filter "*_spec.lua"]] },
       cwd = directory,
     }
   else
@@ -200,7 +201,7 @@ function harness._find_files_to_run(directory)
     }
   end
 
-  return vim.tbl_map(Path.new, finder:sync())
+  return vim.tbl_map(Path.new, finder:sync(vim.env.PLENARY_TEST_TIMEOUT))
 end
 
 function harness._run_path(test_type, directory)

--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -187,7 +187,7 @@ function harness._find_files_to_run(directory)
   local finder
   if vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1 then
     -- On windows use powershell Get-ChildItem instead
-    local cmd = vim.fn.executable("pwsh.exe") == 1 and "pwsh" or "powershell"
+    local cmd = vim.fn.executable "pwsh.exe" == 1 and "pwsh" or "powershell"
     finder = Job:new {
       command = cmd,
       args = { "-NoProfile", "-Command", [[Get-ChildItem -Recurse -n -Filter "*_spec.lua"]] },


### PR DESCRIPTION
Fixes #524. 

I am basing my implementation based on these benchmarks: 
![image](https://github-production-user-asset-6210df.s3.amazonaws.com/92228287/267077386-49968db4-87be-43be-9db0-f06d45e0d34e.png)

My conclusions from my benchmarks above: 
1. `pwsh` is generally faster than using `powershell` 
2.  Using `-NoProfile` flag when using either executable can also optimize the execution time. 

I understand that not every Windows user will have `pwsh` installed on their system, thus they will still be using `powershell`. However, if a user only has `powershell` on their system, even with `-NoProfile` flag, it will still exceed 5000 ms timeout duration, which means that the timeout duration must be increased. In my fix, I am using `vim.env.PLENARY_TEST_TIMEOUT` variable, which is set previously in the module, to remain consistent with plenary timeouts.  