### PR TITLE
Improve `lua-language-server` annotations of `Job` class

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -4,20 +4,21 @@ local uv = vim.loop
 local F = require "plenary.functional"
 
 ---@class Job
----@field command string          : Command to run
----@field args Array              : List of arguments to pass
----@field cwd string              : Working directory for job
----@field env Map|Array           : Environment looking like: { ['VAR'] = 'VALUE } or { 'VAR=VALUE' }
----@field skip_validation boolean : Skip validating the arguments
----@field enable_handlers boolean : If set to false, disables all callbacks associated with output
----@field on_start function       : Run when starting job
----@field on_stdout function      : (error: string, data: string, self? Job)
----@field on_stderr function      : (error: string, data: string, self? Job)
----@field on_exit function        : (self, code: number, signal: number)
----@field maximum_results number  : stop processing results after this number
----@field writer Job|table|string : Job that writes to stdin of this job.
----@field detached boolean        : Spawn the child in a detached state making it a process group leader
----@field enabled_recording boolean
+---@field command string Command to run
+---@field args? string[] List of arguments to pass
+---@field cwd? string Working directory for job
+---@field env? table<string, string>|string[] Environment looking like: { ['VAR'] = 'VALUE' } or { 'VAR=VALUE' }
+---@field interactive? boolean
+---@field detached? boolean Spawn the child in a detached state making it a process group leader
+---@field skip_validation? boolean Skip validating the arguments
+---@field enable_handlers? boolean If set to false, disables all callbacks associated with output (default: true)
+---@field enabled_recording? boolean
+---@field on_start? fun()
+---@field on_stdout? fun(error: string, data: string, self?: Job)
+---@field on_stderr? fun(error: string, data: string, self?: Job)
+---@field on_exit? fun(self: Job, code: number, signal: number)
+---@field maximum_results? number Stop processing results after this number
+---@field writer? Job|table|string Job that writes to stdin of this job.
 local Job = {}
 Job.__index = Job
 


### PR DESCRIPTION
Improve the types using [`lua-language-server annotations`](https://luals.github.io/wiki/annotations/)
- make them as specific as possible
- indicate the optional fields
- added interactive field which was left undocumented (?)
- Comments are all capitalized and space separated from the type (some comments line length would be to long if aligned)