### PR TITLE
feat(test_harness): Add opts to test_harness.test_file

### DIFF
--- a/lua/plenary/test_harness.lua
+++ b/lua/plenary/test_harness.lua
@@ -193,8 +193,9 @@ function harness.test_directory(directory, opts)
   test_paths(paths, opts)
 end
 
-function harness.test_file(filepath)
-  test_paths { Path:new(filepath) }
+function harness.test_file(filepath, opts)
+  local paths = { Path:new(filepath) }
+  test_paths(paths, opts)
 end
 
 function harness._find_files_to_run(directory)


### PR DESCRIPTION
PROBLEM:
There was no way to configure opts (such as init, minimal, etc.) for
running a single file test (`test_harness.test_file(file)`).

SOLUTION:
Add `opts` parameter.
