### PR TITLE
fix: avoid error when it exceeds timeout

### DIFF
--- a/lua/plenary/async/util.lua
+++ b/lua/plenary/async/util.lua
@@ -22,7 +22,8 @@ M.sleep = a.wrap(defer_swapped, 2)
 M.block_on = function(async_function, timeout)
   async_function = M.protected(async_function)
 
-  local stat, ret
+  local stat
+  local ret = {}
 
   a.run(async_function, function(stat_, ...)
     stat = stat_


### PR DESCRIPTION
When I ran this code, I got an error below.

```lua
async.util.block_on(function()
  async.util.sleep(4000)
end)
print "done"
```

```bash
E5113: Error while calling lua chunk: /tmp/hoge.lua:4: bad argument #1 to 'block_on' (table expected, got nil)
stack traceback:
        [C]: in function 'block_on'
        /tmp/hoge.lua:4: in main chunk
```

This means the func is terminated by `vim.wait` and the variable `ret` is still `nil`. So `unpack(ret)` raises an error.

This PR fixes this bug by setting a default value for `ret`.