### PR TITLE
fix: return the results from async.api.*

### DIFF
--- a/lua/plenary/async/api.lua
+++ b/lua/plenary/async/api.lua
@@ -8,7 +8,7 @@ return setmetatable({}, {
         util.scheduler()
       end
 
-      vim.api[k](...)
+      return vim.api[k](...)
     end
   end,
 })


### PR DESCRIPTION
This enables to return results from `async.api.*`. This is useful you call funcs such as `vim.api.nvim_get_current_buf()`.

```lua
local buf = async.api.nvim_get_current_buf()
print(buf) -- print no string in the master, but `1` in this PR build.
```