### PR TITLE
Re-add .log extension to plugin bases logfile name

### DIFF
--- a/lua/plenary/log.lua
+++ b/lua/plenary/log.lua
@@ -79,8 +79,10 @@ local unpack = unpack or table.unpack
 log.new = function(config, standalone)
   config = vim.tbl_deep_extend("force", default_config, config)
 
-  local outfile =
-    vim.F.if_nil(config.outfile, Path:new(vim.api.nvim_call_function("stdpath", { "cache" }), config.plugin..".log").filename)
+  local outfile = vim.F.if_nil(
+    config.outfile,
+    Path:new(vim.api.nvim_call_function("stdpath", { "cache" }), config.plugin .. ".log").filename
+  )
 
   local obj
   if standalone then

--- a/lua/plenary/log.lua
+++ b/lua/plenary/log.lua
@@ -80,7 +80,7 @@ log.new = function(config, standalone)
   config = vim.tbl_deep_extend("force", default_config, config)
 
   local outfile =
-    vim.F.if_nil(config.outfile, Path:new(vim.api.nvim_call_function("stdpath", { "cache" }), config.plugin).filename)
+    vim.F.if_nil(config.outfile, Path:new(vim.api.nvim_call_function("stdpath", { "cache" }), config.plugin..".log").filename)
 
   local obj
   if standalone then


### PR DESCRIPTION
This fixes an issue introduced by https://github.com/nvim-lua/plenary.nvim/pull/521 where it no longer appends `.log` to the filename breaking some plugins when there's also a folder with the same name. 