### PR TITLE
fix(path): add a windows style path pattern to is_absolute()

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -78,7 +78,7 @@ end
 
 local is_absolute = function(filename, sep)
   if sep == "\\" then
-    return string.match(filename, "^[%a]:\\.*$") ~= nil
+    return string.match(filename, "^[%a]:[\\/].*$") ~= nil
   end
   return string.sub(filename, 1, 1) == sep
 end


### PR DESCRIPTION
Currently, Windows-style paths such as `C:\Users\<user>\*` are considered absolute paths.
However, paths such as `C:/Users/<user>/*` are used in some windows environments.

For example, in https://github.com/nvim-lua/plenary.nvim/issues/456, `C:/Users/myhome/my/local/obsidian/repo/` is used as a path.
Current implementation do not consider `C:/Users/myhome/my/local/obsidian/repo/` as an absolute path.
As a result, the cwd path (`C:\Users\myhome\AppData\Local\nvim\lua`) is prepended.

This PR should fix this problems and https://github.com/nvim-lua/plenary.nvim/issues/456.