### PR TITLE
feat: option to use custom curl bin

### DIFF
--- a/lua/plenary/curl.lua
+++ b/lua/plenary/curl.lua
@@ -269,7 +269,7 @@ local request = function(specs)
   end
 
   local job_opts = {
-    command = "curl",
+    command = vim.g.plenary_curl_bin_path or "curl",
     args = args,
   }
   if opts.stream then


### PR DESCRIPTION
ref: https://github.com/kawre/leetcode.nvim/issues/44

TLDR: if you use `msys` curl on windows, and use -d with a path to a payload file, `msys` will not make the command execute unless you wrap the payload with `'`. I guess the simplest solution to this is to have an option to specify custom curl bin path, so if the user still wishes to use `msys` as the default curl, they still have an option to specify for example `cygwin` as the curl that `plenary.nvim` will use.