### PR TITLE
fixup: stream option handling in curl

### DIFF
--- a/lua/plenary/curl.lua
+++ b/lua/plenary/curl.lua
@@ -272,29 +272,30 @@ local request = function(specs)
     command = "curl",
     args = args,
   }
+
   if opts.stream then
     job_opts.on_stdout = opts.stream
-  else
-    job_opts.on_exit = function(j, code)
-      if code ~= 0 then
-        local stderr = vim.inspect(j:stderr_result())
-        local message = string.format("%s %s - curl error exit_code=%s stderr=%s", opts.method, opts.url, code, stderr)
-        if opts.on_error then
-          return opts.on_error {
-            message = message,
-            stderr = stderr,
-            exit = code,
-          }
-        else
-          error(message)
-        end
-      end
-      local output = parse.response(j:result(), opts.dump[2], code)
-      if opts.callback then
-        return opts.callback(output)
+  end
+
+  job_opts.on_exit = function(j, code)
+    if code ~= 0 then
+      local stderr = vim.inspect(j:stderr_result())
+      local message = string.format("%s %s - curl error exit_code=%s stderr=%s", opts.method, opts.url, code, stderr)
+      if opts.on_error then
+        return opts.on_error {
+          message = message,
+          stderr = stderr,
+          exit = code,
+        }
       else
-        response = output
+        error(message)
       end
+    end
+    local output = parse.response(j:result(), opts.dump[2], code)
+    if opts.callback then
+      return opts.callback(output)
+    else
+      response = output
     end
   end
   local job = J:new(job_opts)


### PR DESCRIPTION
There are two major problems when supplying `opts.stream` for curl methods:

1. curl methods produce junk in temp folder. Curl command dumps
   headers to some file in tmp folder and cleans it up only in the
   `parse.response()` method. This method is not called if 
   `opts.stream` is set
2. there is no way to access response code, because it is also written to
   the headers dump file in temp folder.

This PR address both of those problems by setting `job.on_exit` callback
even if `opts.stream` is provided. Methods themselves still return job, but
now user has an option to also set `opts.callback` to inspect the response
and curl cleans up the junk in temp folder
