### PR TITLE
feat(#560): scandir adds link entry if it is a directory.

### DIFF
--- a/lua/plenary/scandir.lua
+++ b/lua/plenary/scandir.lua
@@ -100,6 +100,13 @@ local gen_search_pat = function(pattern)
 end
 
 local process_item = function(opts, name, typ, current_dir, next_dir, bp, data, giti, msp)
+   if typ == "link" and opts.links then
+      local entry = uv.fs_readlink(current_dir .. "/" .. name)
+      local ln_type = uv.fs_stat(entry).type
+      if ln_type == "directory" then
+	 table.insert(data, entry)
+      end
+   end
   if opts.hidden or name:sub(1, 1) ~= "." then
     if typ == "directory" then
       local entry = current_dir .. os_sep .. name


### PR DESCRIPTION
Hi, I'm the author of [Whaler.nvim](https://github.com/salorak/whaler.nvim). I had a feature added ( [issue here](https://github.com/SalOrak/whaler.nvim/issues/20) ) to the plugin which under the hook uses plenary.

The idea is that whaler scan for subdirectories in a directory specified by the user but in the current state of plenary.nvim it does not contemplate symlinks to directories. 

This PR modifies the scandir function (sync only) adding symlinks directories when found. It does not apply any recursion whatsoever.

Following issue #560 