### PR TITLE
fix(path): make find_upwards stop at root

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -929,7 +929,9 @@ end
 
 function Path:find_upwards(filename)
   local folder = Path:new(self)
-  while self:absolute() ~= path.root do
+  local root = path.root(folder)
+
+  while folder:absolute() ~= root do
     local p = folder:joinpath(filename)
     if p:exists() then
       return p


### PR DESCRIPTION
When there is no file to be found `find_upwards` gets stuck in an infinite-loop.
This PR should address this.