### PR TITLE
Fixed Path:find_upwards going into an infinite loop

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -929,7 +929,7 @@ end
 
 function Path:find_upwards(filename)
   local folder = Path:new(self)
-  while self:absolute() ~= path.root do
+  while folder:absolute() ~= path.root() do
     local p = folder:joinpath(filename)
     if p:exists() then
       return p


### PR DESCRIPTION
Hi. I recently started using plenary to discover root folders using `Path:find_upwards` but neovim kept freezing.

I modified the code slightly and no longer have issues with this function on my end.

I quickly searched for other issues mentioning this issue on your repository but didn't find any.

In any case, thanks for the awesome library !