### PR TITLE
fix(popup): create popup after `set nomodifiable`, closes #570

### DIFF
--- a/lua/plenary/popup/init.lua
+++ b/lua/plenary/popup/init.lua
@@ -123,6 +123,9 @@ function popup.create(what, vim_options)
     assert(bufnr, "Failed to create buffer")
 
     vim.api.nvim_buf_set_option(bufnr, "bufhidden", "wipe")
+    if vim.o.modifiable == false then
+      vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
+    end
 
     -- TODO: Handle list of lines
     if type(what) == "string" then

--- a/tests/plenary/popup_spec.lua
+++ b/tests/plenary/popup_spec.lua
@@ -22,6 +22,19 @@ describe("plenary.popup", function()
     eq(20, win_config.width)
   end)
 
+  it("can create a very simple window after 'set nomodifiable'", function()
+    vim.o.modifiable = false
+    local win_id = popup.create("hello there", {
+      line = 1,
+      col = 1,
+      width = 20,
+    })
+
+    local win_config = vim.api.nvim_win_get_config(win_id)
+    eq(20, win_config.width)
+    vim.o.modifiable = true
+  end)
+
   it("can apply a highlight", function()
     local win_id = popup.create("hello there", {
       highlight = "PopupColor1",


### PR DESCRIPTION
If running something like:

```lua
vim.o.modifiable = false -- remove this line and it will work.
require("plenary.popup").create("A popup", {})
```

Throws the following error and doesn't create a popup:
<img width="1140" alt="Error after creating a popup" src="https://github.com/nvim-lua/plenary.nvim/assets/71392160/e4581358-fb9a-4642-99da-3495f3a31dd8">

With these changes, it creates the popup without throwing an error.

Tests results:
```txt
========================================
Testing:        /Users/aome/dev/nvim_plugins/plenary.nvim/tests/plenary/popup_spec.lua
Success ||      plenary.popup can create a very simple window
Success ||      plenary.popup can create a very simple window after 'set nomodifiable'
Success ||      plenary.popup can apply a highlight
Success ||      plenary.popup can create a border
Success ||      plenary.popup can apply a border highlight
Success ||      plenary.popup can ignore border highlight with no border
Success ||      plenary.popup can do basic padding
Success ||      plenary.popup can do padding and border
Success ||      plenary.popup borderchars can support multiple border patterns
Success ||      plenary.popup borderchars can support multiple patterns inside the borderchars
Success ||      plenary.popup what can be an existing bufnr
Pending ||      plenary.popup cursor not yet tested

Success:        11
Failed :        0
Errors :        0
========================================
```

Closes #570.