### PR TITLE
fix(log): print `-0` when `number = 0`, closes #569

### DIFF
--- a/lua/plenary/log.lua
+++ b/lua/plenary/log.lua
@@ -97,6 +97,9 @@ log.new = function(config, standalone)
   end
 
   local round = function(x, increment)
+    if x == 0 then
+      return x
+    end
     increment = increment or 1
     x = x / increment
     return (x > 0 and math.floor(x + 0.5) or math.ceil(x - 0.5)) * increment
@@ -108,11 +111,7 @@ log.new = function(config, standalone)
       local x = select(i, ...)
 
       if type(x) == "number" and config.float_precision then
-        if x ~= 0 then
-          x = tostring(round(x, config.float_precision))
-        else
-          x = tostring(x)
-        end
+        x = tostring(round(x, config.float_precision))
       elseif type(x) == "table" then
         x = vim.inspect(x)
       else

--- a/lua/plenary/log.lua
+++ b/lua/plenary/log.lua
@@ -108,7 +108,11 @@ log.new = function(config, standalone)
       local x = select(i, ...)
 
       if type(x) == "number" and config.float_precision then
-        x = tostring(round(x, config.float_precision))
+        if x ~= 0 then
+          x = tostring(round(x, config.float_precision))
+        else
+          x = tostring(x)
+        end
       elseif type(x) == "table" then
         x = vim.inspect(x)
       else


### PR DESCRIPTION
When the number was 0, it was trying to use `round(number, increment)` to floor the number 0, resulting in -0.

I added and if statement that returns the number if it is 0, so it doesn't try to round it.

Tested with the case provided in #569.

```lua
local M = {}

local my_hash = {
  args = "!p4print checker.sv",
  bang = false,
  count = -1,
  fargs = { "!p4print checker.sv" },
  line1 = 2,
  line2 = 2,
  mods = "",
  name = "Redir",
  range = 0,
  reg = "",
  smods = {
    browse = false,
    confirm = false,
    emsg_silent = false,
    hide = false,
    horizontal = false,
    keepalt = false,
    keepjumps = false,
    keepmarks = false,
    keeppatterns = false,
    lockmarks = false,
    noautocmd = false,
    noswapfile = false,
    sandbox = false,
    silent = false,
    split = "",
    tab = -1,
    unsilent = false,
    verbose = -1,
    vertical = false
  }
}
local log = require('plenary.log'):new()
log.level = 'debug'

function M.Redir(opts)
  -- M.P("Redir::opts", opts)
  local cmd = opts.args
  local rng = opts.range
  local start = opts.line1
  local ending = opts.line2
  log.debug("Redir::opts", opts)
  log.debug("Redir::cmd", cmd)
  log.debug("Redir::opts.range", opts.range)
  log.debug("Redir::rng", rng)
  log.debug("Redir::start", start)
  log.debug("Redir::ending", ending)
end
M.Redir(my_hash)

--[[
|| [plenary] [DEBUG 07:46:04] function_in_buffer.lua:51: Redir::cmd !p4print checker.sv
|| [plenary] [DEBUG 07:46:04] function_in_buffer.lua:52: Redir::opts.range 0
|| [plenary] [DEBUG 07:46:04] function_in_buffer.lua:53: Redir::rng 0
|| [plenary] [DEBUG 07:46:04] function_in_buffer.lua:54: Redir::start 2
|| [plenary] [DEBUG 07:46:04] function_in_buffer.lua:55: Redir::ending 2
]]
```

Closes #569.