### PR TITLE
feat(filetypes): add cppm filetype

### DIFF
--- a/data/plenary/filetypes/base.lua
+++ b/data/plenary/filetypes/base.lua
@@ -647,6 +647,7 @@ return {
     ['tfstate.backup'] = [[json]],
     ['bzl'] = [[bzl]],
     ['cpp'] = [[cpp]],
+    ['cppm'] = [[cpp]],
     ['mod'] = [[ampl]],
     ['idc'] = [[c]],
     ['hh'] = [[cpp]],


### PR DESCRIPTION
one-liner so that plenary.get_filetype('something.cppm') returns "cpp".