### PR TITLE
fix: deprecated vim.tbl_islist -> vim.islist

### DIFF
--- a/lua/plenary/iterators.lua
+++ b/lua/plenary/iterators.lua
@@ -107,7 +107,7 @@ local rawiter = function(obj, param, state)
       end
     end
 
-    if vim.tbl_islist(obj) then
+    if vim.islist(obj) then
       return ipairs(obj)
     else
       -- hash

--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -416,7 +416,7 @@ function Job:_execute()
   if self.writer then
     if Job.is_job(self.writer) then
       self.writer:_execute()
-    elseif type(self.writer) == "table" and vim.tbl_islist(self.writer) then
+    elseif type(self.writer) == "table" and vim.islist(self.writer) then
       local writer_len = #self.writer
       for i, v in ipairs(self.writer) do
         self.stdin:write(v)

--- a/tests/plenary/path_spec.lua
+++ b/tests/plenary/path_spec.lua
@@ -592,7 +592,7 @@ describe("Path", function()
     it("should extract the ancestors of the path", function()
       local p = Path:new(vim.loop.cwd())
       local parents = p:parents()
-      assert(vim.tbl_islist(parents))
+      assert(vim.islist(parents))
       for _, parent in pairs(parents) do
         assert.are.same(type(parent), "string")
       end


### PR DESCRIPTION
See `Lua stdlib` section for 0.10 deprecations
https://neovim.io/doc/user/deprecated.html#deprecated-0.10