### PR TITLE
ci: bump ci versions

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -17,7 +17,9 @@ jobs:
           - os: ubuntu-22.04
             rev: v0.8.3/nvim-linux64.tar.gz
           - os: ubuntu-22.04
-            rev: v0.9.1/nvim-linux64.tar.gz
+            rev: v0.9.5/nvim-linux64.tar.gz
+          - os: ubuntu-22.04
+            rev: v0.10.0/nvim-linux64.tar.gz
     steps:
       - uses: actions/checkout@v3
       - run: date +%F > todays-date


### PR DESCRIPTION
Bump 0.9 release to final
Add explicit 0.10 tests now its not nightly