### PR TITLE
Winpathfix

### DIFF
--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -18,10 +18,12 @@ local S_IF = {
 local path = {}
 path.home = vim.loop.os_homedir()
 
+local sls_exists = vim.fn.exists('+shellslash')
+
 path.sep = (function()
   if jit then
     local os = string.lower(jit.os)
-    if os ~= "windows" then
+    if os ~= "windows" or vim.opt.shellslash._value then
       return "/"
     else
       return "\\"
@@ -32,14 +34,14 @@ path.sep = (function()
 end)()
 
 path.root = (function()
-  if path.sep == "/" then
+  if path.sep == "/" and not sls_exists then
     return function()
       return "/"
     end
   else
     return function(base)
       base = base or vim.loop.cwd()
-      return base:sub(1, 1) .. ":\\"
+      return base:sub(1, 1) .. ":" .. path.sep
     end
   end
 end)()
@@ -55,8 +57,8 @@ local concat_paths = function(...)
 end
 
 local function is_root(pathname)
-  if path.sep == "\\" then
-    return string.match(pathname, "^[A-Z]:\\?$")
+  if sls_exists then
+    return string.match(pathname, "^[A-Z]:" .. path.sep .. "?$")
   end
   return pathname == "/"
 end
@@ -77,8 +79,8 @@ local is_uri = function(filename)
 end
 
 local is_absolute = function(filename, sep)
-  if sep == "\\" then
     return string.match(filename, "^[%a]:[\\/].*$") ~= nil
+  if sls_exists then
   end
   return string.sub(filename, 1, 1) == sep
 end
@@ -103,7 +105,7 @@ local function _normalize_path(filename, cwd)
     local split_without_disk_name = function(filename_local)
       local parts = _split_by_separator(filename_local)
       -- Remove disk name part on Windows
-      if path.sep == "\\" and is_abs then
+      if sls_exists and is_abs then
         table.remove(parts, 1)
       end
       return parts
@@ -137,7 +139,7 @@ local function _normalize_path(filename, cwd)
     out_file = prefix .. table.concat(parts, path.sep)
   end
 
-  return out_file
+  return vim.fs.normalize(out_file, {expand_env=false})
 end
 
 local clean = function(pathname)
@@ -435,7 +437,7 @@ local shorten = (function()
     return shorten_len(filename, 1)
   end
 
-  if jit and path.sep ~= "\\" then
+  if jit and not sls_exists then
     local ffi = require "ffi"
     ffi.cdef [[
     typedef unsigned char char_u;
@@ -489,7 +491,7 @@ function Path:mkdir(opts)
       for _, dir in ipairs(dirs) do
         if dir ~= "" then
           local joined = concat_paths(processed, dir)
-          if processed == "" and self._sep == "\\" then
+          if processed == "" and sls_exists then
             joined = dir
           end
           local stat = uv.fs_stat(joined) or {}

--- a/lua/plenary/path.lua
+++ b/lua/plenary/path.lua
@@ -58,7 +58,7 @@ end
 
 local function is_root(pathname)
   if sls_exists then
-    return string.match(pathname, "^[A-Z]:" .. path.sep .. "?$")
+    return string.match(pathname, "^[A-Z]:[\\/]?$")
   end
   return pathname == "/"
 end
@@ -79,8 +79,8 @@ local is_uri = function(filename)
 end
 
 local is_absolute = function(filename, sep)
-    return string.match(filename, "^[%a]:[\\/].*$") ~= nil
   if sls_exists then
+    return string.match(filename, "^[%a]:[\\/].*$") ~= nil
   end
   return string.sub(filename, 1, 1) == sep
 end


### PR DESCRIPTION
The misguided assumption that the path separator on Windows would always be a backslash, and therefore that checking if the path separator was a backslash was equivalent to checking if the OS was Windows, there were issues with path normalization when using forward slash as the path separator on Windows (with the `'shellslash'` option set).

My tweaks involve checking for the existence of the `'shellslash'` option to determine whether or not to use Windows-style paths, and (if it does exist) checking its value to determine which path separator to expect. I also added the invocation of the `vim.fs.normalize` function at the end of the Plenary path normalization function to hopefully catch any edge cases, although in hindsight it's probably best to only invoke it when there are still both forward and backward slashes in the path at that point.