### PR TITLE
feat(curl): add option to disallow redirections

### DIFF
--- a/lua/plenary/curl.lua
+++ b/lua/plenary/curl.lua
@@ -15,6 +15,7 @@ all curl methods accepts
   http_version = "HTTP version to use: 'HTTP/0.9', 'HTTP/1.0', 'HTTP/1.1', 'HTTP/2', or 'HTTP/3'" (string)
   proxy        = "[protocol://]host[:port] Use this proxy" (string)
   insecure     = "Allow insecure server connections" (boolean)
+  redirect     = "Allow redirection" (boolean)
 
 and returns table:
 
@@ -214,7 +215,7 @@ parse.request = function(opts)
       opts.raw_body = b
     end
   end
-  local result = { "-sSL", opts.dump }
+  local result = { "-sS", opts.dump }
   local append = function(v)
     if v then
       table.insert(result, v)
@@ -229,6 +230,9 @@ parse.request = function(opts)
   end
   if opts.compressed then
     table.insert(result, "--compressed")
+  end
+  if opts.redirect ~= false then
+    table.insert(result, '-L')
   end
   append(parse.method(opts.method))
   append(parse.headers(opts.headers))


### PR DESCRIPTION
While developing plugins using `plenary.nvim`, I notice that it calls `curl` with option `-L` by default. However, the website I am working with uses status code 302 to mark the login successful, which leads to an infinite redirection in my plugin. I think it would be good to add support for disabling following redirection, so I add a new option `redirect` which is `true` by default.