### PR TITLE
fix(log): Use `stdpath('log')`

### DIFF
--- a/lua/plenary/log.lua
+++ b/lua/plenary/log.lua
@@ -27,7 +27,7 @@ local default_config = {
   highlights = true,
 
   -- Should write to a file.
-  -- Default output for logging file is `stdpath("cache")/plugin`.
+  -- Default output for logging file is `stdpath("log")/plugin.log`.
   use_file = true,
 
   -- Output file has precedence over plugin, if not nil.
@@ -81,7 +81,7 @@ log.new = function(config, standalone)
 
   local outfile = vim.F.if_nil(
     config.outfile,
-    Path:new(vim.api.nvim_call_function("stdpath", { "cache" }), config.plugin .. ".log").filename
+    Path:new(vim.api.nvim_call_function("stdpath", { "log" }), config.plugin .. ".log").filename
   )
 
   local obj


### PR DESCRIPTION
Neovim has had a standard path for log files since `v0.7.0-322-g78a1e6bc0` (note this is *after* v0.7.2; the `git describe` output is a touch misleading), so this should be the preferred location. Logs aren't cache data, so they shouldn't be stored with cache data.

Given that plenary is used in a lot of plugins, this would be a tiny but free improvement in correctness for many plugins out there.

Related: #93, #487.

Fun fact: #93 was merged just 6 months before `stdpath('log')` landed!