### PR TITLE
feat: add cairo language filetype

### DIFF
--- a/data/plenary/filetypes/builtin.lua
+++ b/data/plenary/filetypes/builtin.lua
@@ -21,6 +21,7 @@ return {
   extension = {
     ['_coffee'] = 'coffee',
     ['astro'] = 'astro',
+    ['cairo'] = 'cairo',
     ['cts'] = 'typescript',
     ['cljd'] = 'clojure',
     ['coffee'] = 'coffee',


### PR DESCRIPTION
Added a new filetype for the cairo language: https://www.cairo-lang.org/

Telescope without filetype:
<img width="1601" alt="image" src="https://github.com/user-attachments/assets/db1825a1-6635-46ee-8837-ccdaef05a327">

Telescope with the filetype:
<img width="1601" alt="image" src="https://github.com/user-attachments/assets/b66725db-0b6d-47d1-97da-c6fc66c56e74">
