### PR TITLE
feat(json): add abliity to remove trailing commas while stripping comments

### DIFF
--- a/tests/plenary/json_spec.lua
+++ b/tests/plenary/json_spec.lua
@@ -67,4 +67,21 @@ describe("json", function()
       [[{"x":"x \"sed -e \\\"s/^.\\\\{46\\\\}T//\\\" -e \\\"s/#033/\\\\x1b/g\\\"\""}]]
     )
   end)
+
+  it("trailing commas", function()
+    eq(json.json_strip_comments '{"a":"b",}', '{"a":"b"}')
+    eq(json.json_strip_comments '{"a":{"b":"c",},}', '{"a":{"b":"c"}}')
+    eq(json.json_strip_comments '{"a":["b","c",],}', '{"a":["b","c"]}')
+  end)
+
+  it("trailing commas - ignored in strings and comments", function()
+    eq(json.json_strip_comments '{"a":"b,}"}', '{"a":"b,}"}')
+  end)
+
+  it("trailing commas - left when disabled in options", function()
+    local options = { trailing_commas = true }
+    eq(json.json_strip_comments('{"a":"b",}', options), '{"a":"b",}')
+    eq(json.json_strip_comments('{"a":{"b":"c",},}', options), '{"a":{"b":"c",},}')
+    eq(json.json_strip_comments('{"a":["b","c",],}', options), '{"a":["b","c",],}')
+  end)
 end)


### PR DESCRIPTION
This adds an additional feature to the `json_strip_comments` function that adds more compatibility for converting a JSON string to something compatible with `vim.fn.json_decode`. I also added tests to make sure things like commas in strings are fully ignored and that it doesn't mess up the already existing comment stripping.

Resolves #612 