### PR TITLE
fix(scandir): respect gitignore only if under its scope in case of scanning multiple paths

### DIFF
--- a/lua/plenary/scandir.lua
+++ b/lua/plenary/scandir.lua
@@ -47,15 +47,17 @@ local make_gitignore = function(basepath)
     for _, v in ipairs(bp) do
       if entry:find(v, 1, true) then
         local negated = false
-        for _, w in ipairs(patterns[v].ignored) do
-          if not negated and entry:match(w) then
-            for _, inverse in ipairs(patterns[v].negated) do
-              if not negated and entry:match(inverse) then
-                negated = true
+        if patterns[v] then
+          for _, w in ipairs(patterns[v].ignored) do
+            if not negated and entry:match(w) then
+              for _, inverse in ipairs(patterns[v].negated) do
+                if not negated and entry:match(inverse) then
+                  negated = true
+                end
               end
-            end
-            if not negated then
-              return false
+              if not negated then
+                return false
+              end
             end
           end
         end

--- a/tests/plenary/scandir_spec.lua
+++ b/tests/plenary/scandir_spec.lua
@@ -126,6 +126,38 @@ describe("scandir", function()
       eq(false, contains(dirs, "./asdf/asdf/adsf.lua"))
     end)
 
+    it("with respect_gitignore on mixed paths", function()
+      vim.cmd ":silent !mkdir -p test_path_root/projectdir"
+      vim.cmd(
+        ":silent !touch "
+          .. "test_path_root/projectdir/README.md "
+          .. "test_path_root/projectdir/LICENSE "
+          .. "test_path_root/projectdir/test.so "
+          .. "test_path_root/external_file.txt"
+      )
+      vim.cmd ":silent !cp .gitignore test_path_root/projectdir/"
+      vim.cmd ":cd test_path_root/projectdir/"
+
+      local dirs = scan.scan_dir({ ".", ".." }, { respect_gitignore = true })
+
+      vim.cmd ":cd ../../"
+      vim.cmd(
+        ":silent !rm "
+          .. "test_path_root/projectdir/README.md "
+          .. "test_path_root/projectdir/LICENSE "
+          .. "test_path_root/projectdir/test.so "
+          .. "test_path_root/external_file.txt "
+          .. "test_path_root/projectdir/.gitignore"
+      )
+      vim.cmd ":silent !rmdir test_path_root/projectdir test_path_root"
+
+      eq("table", type(dirs))
+      eq(true, contains(dirs, "./README.md"))
+      eq(true, contains(dirs, "./LICENSE"))
+      eq(true, contains(dirs, "../external_file.txt"))
+      eq(false, contains(dirs, "./test.so"))
+    end)
+
     it("with search pattern", function()
       local dirs = scan.scan_dir(".", { search_pattern = "filetype" })
       eq("table", type(dirs))


### PR DESCRIPTION
This PR fixes the following scenario:
- `respect_gitignore` is true
- path argument to scan is a list containing a project directory having a `gitignore` file and other paths outside of this project directory, e.g.:
  - `/tmp/some_project_dir` (this is the current directory too, having the `gitignore` file) 
  - `/other_path_1/subdir_1`
  - `/other_path_2/subdir_2`

If `scan_dir` runs, it tries to match the gitignore rule of the current working directory for the `/other_path_{1,2}` paths and throws `scandir.lua:49: attempt to index a nil value`.
 