### PR TITLE
fix: return early to avoid errors with no asyncfns

### DIFF
--- a/lua/plenary/async/util.lua
+++ b/lua/plenary/async/util.lua
@@ -53,6 +53,10 @@ end
 M.join = function(async_fns)
   local len = #async_fns
   local results = {}
+  if len == 0 then
+    return results
+  end
+
   local done = 0
 
   local tx, rx = channel.oneshot()


### PR DESCRIPTION
When no async functions are supplied, it will be stuck because rx() waits forever. This diff fixes it.