### PR TITLE
fix(popup)!: `moved="any"`, `enter` default, `callback=fn`

### DIFF
--- a/POPUP.md
+++ b/POPUP.md
@@ -10,6 +10,7 @@ stablization and any required features are merged into Neovim, we can upstream
 this and expose the API in vimL to create better compatibility.
 
 ## Notices
+- **2024-09-19:** change `enter` default to false to follow Vim.
 - **2021-09-19:** we now follow Vim's convention of the first line/column of the screen being indexed 1, so that 0 can be used for centering.
 - **2021-08-19:** we now follow Vim's default to `noautocmd` on popup creation. This can be overriden with `vim_options.noautocmd=false`
 
@@ -34,19 +35,26 @@ Unlikely (due to technical difficulties):
     - textprop
     - textpropwin
     - textpropid
-- [ ] "close"
-    - But this is mostly because I don't know how to use mouse APIs in nvim. If someone knows. please make an issue in the repo, and maybe we can get it sorted out.
 
 Unlikely (due to not sure if people are using):
 - [ ] tabpage
 
 ## Progress
 
+Suported Functions:
+
+- [x] popup.create
+- [x] popup.move
+- [ ] popup.close
+- [ ] popup.clear
+
+
 Suported Features:
 
 - [x] what
     - string
     - list of strings
+    - bufnr
 - [x] popup_create-arguments
     - [x] border
     - [x] borderchars
@@ -69,6 +77,25 @@ Suported Features:
     - [x] title
     - [x] wrap
     - [x] zindex
+    - [x] callback
+    - [ ] mousemoved
+        - [ ] "any"
+        - [ ] "word"
+        - [ ] "WORD"
+        - [ ] "expr"
+        - [ ] (list options)
+    - [?] close
+        - [ ] "button"
+        - [ ] "click"
+        - [x] "none"
+
+
+Additional Features:
+
+- [x] enter
+- [x] focusable
+- [x] noautocmd
+- [x] finalize_callback
 
 ## All known unimplemented vim features at the moment
 
@@ -79,10 +106,7 @@ Suported Features:
 - filter
 - filtermode
 - mapping
-- callback
 - mouse:
-    - mousemoved
-    - close
     - drag
     - resize
 

--- a/lua/plenary/popup/utils.lua
+++ b/lua/plenary/popup/utils.lua
@@ -14,6 +14,9 @@ utils.bounded = function(value, min, max)
   return value
 end
 
+-- TODO:    Should defaults get deepcopy before table values are used?
+--          utils.apply_defaults is never used AFAICT.
+--          So I guess this comment is about plenary/tbl.lua.
 utils.apply_defaults = function(original, defaults)
   if original == nil then
     original = {}

--- a/tests/plenary/popup_spec.lua
+++ b/tests/plenary/popup_spec.lua
@@ -130,6 +130,82 @@ describe("plenary.popup", function()
     })
   end)
 
+  describe("callback option", function()
+    local callback_result
+    local function callback(wid, result)
+      callback_result = result
+    end
+
+    it("without a callback", function()
+      callback_result = nil
+      local popup_wid = popup.create("hello there", {})
+      vim.api.nvim_win_close(popup_wid, true)
+
+      eq(nil, callback_result)
+    end)
+
+    it("with a callback", function()
+      callback_result = nil
+      local popup_wid = popup.create("hello there", {
+        callback = callback,
+      })
+      vim.api.nvim_win_close(popup_wid, true)
+
+      eq(-1, callback_result)
+    end)
+  end)
+
+  describe("enter option", function()
+    it("enter not specified", function()
+      local main_wid = vim.fn.win_getid()
+      -- same as enter = false
+      local popup_wid = popup.create("hello there", {})
+      cur_wid = vim.fn.win_getid()
+      -- current window should still be the main window
+      eq(main_wid, cur_wid)
+      vim.api.nvim_win_close(popup_wid, true)
+    end)
+
+    it("enter = false", function()
+      local main_wid = vim.fn.win_getid()
+      local popup_wid = popup.create("hello there", {
+        enter = false,
+      })
+      cur_wid = vim.fn.win_getid()
+      -- current window should still be the main window
+      eq(main_wid, cur_wid)
+      vim.api.nvim_win_close(popup_wid, true)
+    end)
+
+    it("enter = true", function()
+      local main_wid = vim.fn.win_getid()
+      local popup_wid = popup.create("hello there", {
+        enter = true,
+      })
+      cur_wid = vim.fn.win_getid()
+      -- current window should be the popup
+      eq(popup_wid, cur_wid)
+      vim.api.nvim_win_close(popup_wid, true)
+    end)
+  end)
+
+  describe("moved option", function()
+    local callback_result
+    local function callback(wid, result)
+      callback_result = result
+    end
+
+    it("with moved but not used", function()
+      callback_result = nil
+      local popup_wid = popup.create("hello there", {
+        moved = "any",
+        callback = callback,
+      })
+      vim.api.nvim_win_close(popup_wid, true)
+      eq(-1, callback_result)
+    end)
+  end)
+
   describe("what", function()
     it("can be an existing bufnr", function()
       local bufnr = vim.api.nvim_create_buf(false, false)


### PR DESCRIPTION
(I'm looking at adding `mousemoved='any'`, `close='click'`, and `popup_close()` to popups; came across a few things to fix first.)

**To reviewers**
This is my first `neovim` related PR and my first `lua` code. Suggestions about style... welcome. Not sure how this repo handles reviews, so I'm tagging some names that have done some popup work (sorry for the noise). There's some TODO I scattered with questions, looking for feedback (would like to remove before merge). There's a probable bug in tbl.apply_defaults, noted in popup/utils.lua.

@l-kershaw @fdschmidt93 @AlejandroSuero @xactlyblue @jesseleite
@Conni2461 @tjdevries

- Fix `moved = 'any'` option.
  Before this PR, the popup option "moved = 'any'," gets an exception because of changes made to vim.lsp.util.close_preview_autocmd:
  - https://github.com/neovim/neovim/pull/19283 changed the behavior,
  - https://github.com/neovim/neovim/pull/16557 changed the accessibility,

  Those changes looks like a fix. The now private code from "...lsp.util" is copied in here and the the buffer numbers are added as needed for the new code.

- Default the new option `enter` to `false`
  Changed the default to false, so the behavior matches `vim` with no options; which is to leave the cursor where it was and not change the focus to the popup. Is there a place to note breaking changes? Wonder the reason for "enter" option?

- Fix callback
  I couldn't get it to work in a simple case. Converted to an autocmd. Comments on potential timing issues? Accessing buffer in callback does work. There's some preliminary work to support "popup_close(win_id, result)" and mouse stuff for a later PR.

- Update POPUP.md

**Tests**

The options `callback` and `enter` are tested. The option `moved` only has a partial test which verifies the option can be used (it fails without this PR). https://github.com/nvim-lua/plenary.nvim/pull/622#issuecomment-2364761291 details the problems I'm having with getting the tests to work. Will revisit if/when I understand the trick that's needed.

**Could also do ...**

There's dict_default(). Would using tbl.apply_defaults make sense? Seems cleaner.
Should tbl.apply_defaults do a deepcopy of any table from defaults?

There was a comment around the callback setup.
> Giving win_id is pointless here because it's closed right afterwards
> but it might make more sense once hidden is implemented

I've removed the comment. The called back function may want to know the win_id; for example,
there could be a data structure associated with the win_id that can be freed.

**PS**: For the stuff I'm looking at adding, I could open a discussion or just do the PR and discuss there; recommendation?
