### PR TITLE
fix: remove formatting header keys for curl

### DIFF
--- a/lua/plenary/curl.lua
+++ b/lua/plenary/curl.lua
@@ -91,20 +91,7 @@ parse.headers = function(t)
   if not t then
     return
   end
-  local upper = function(str)
-    return string.gsub(" " .. str, "%W%l", string.upper):sub(2)
-  end
-  return util.kv_to_list(
-    (function()
-      local normilzed = {}
-      for k, v in pairs(t) do
-        normilzed[upper(k:gsub("_", "%-"))] = v
-      end
-      return normilzed
-    end)(),
-    "-H",
-    ": "
-  )
+  return util.kv_to_list(t, "-H", ": ")
 end
 
 parse.data_body = function(t)


### PR DESCRIPTION
Removes formatting of header keys. This allows usage of the curl to have headers exactly as what users pass in