### PR TITLE
fix: process all data on_output, even when not terminated with newline

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -361,7 +361,7 @@ local on_output = function(self, result_key, cb)
         cb(err, result_line, self)
       end
 
-      if data == nil or is_complete then
+      if is_complete then
         return
       end
 

--- a/tests/plenary/job_spec.lua
+++ b/tests/plenary/job_spec.lua
@@ -99,7 +99,7 @@ describe("Job", function()
       assert.are.same(job:result(), results)
     end)
 
-    pending("should split stdin across newlines with no ending newline", function()
+    it("should split stdin across newlines with no ending newline", function()
       local results = {}
       local job = Job:new {
         -- writer = "hello\nword\nthis is\ntj",
@@ -113,6 +113,8 @@ describe("Job", function()
       job:start()
       job:send "hello\nwor"
       job:send "ld"
+
+      wait_for_result(job, { "hello", "world" })
       job:shutdown()
 
       assert.are.same(job:result(), { "hello", "world" })
@@ -137,7 +139,7 @@ describe("Job", function()
       assert.are.same(job:result(), results)
     end)
 
-    pending("should return last line when there is no ending newline", function()
+    it("should return last line when there is no ending newline", function()
       local results = {}
       local job = Job:new {
         command = "printf",


### PR DESCRIPTION
The current condition prematurely quits processing of data in on_output
in some edge-cases.

In these cases `job:result()` will have all data, but not everyting was
sent through the `on_output` pipes.

Closes https://github.com/nvim-lua/plenary.nvim/issues/634

Thanks for your support, please let me know your thoughts!