### PR TITLE
fix: handle winborder in neovim-0.11

### DIFF
--- a/lua/plenary/popup/init.lua
+++ b/lua/plenary/popup/init.lua
@@ -191,6 +191,7 @@ function popup.create(what, vim_options)
   local win_opts = {}
   win_opts.relative = "editor"
   win_opts.style = "minimal"
+  win_opts.border = "none"
 
   -- Add positional and sizing config to win_opts
   add_position_config(win_opts, vim_options, { width = 1, height = 1 })

--- a/lua/plenary/window/border.lua
+++ b/lua/plenary/window/border.lua
@@ -231,6 +231,7 @@ function Border:__align_calc_config(content_win_options, border_win_options)
     zindex = content_win_options.zindex or 50,
     noautocmd = content_win_options.noautocmd,
     focusable = vim.F.if_nil(border_win_options.focusable, false),
+    border = "none",
   }
 
   return nvim_win_config


### PR DESCRIPTION
neovim 0.11 introduced winborder: https://github.com/neovim/neovim/pull/31074 

This means that the user may override the global window border for all windows for which the border wasn't explicitly set.

In the past we achieved borderless windows by not specifying a border, but with winborder, the user may set the border and then the UI looks broken. So now we explicitly say that we want no border on the windows where we intended it so.

I tested this commit on neovim 0.10.2 as well, without issues.

To reproduce the issue on neovim 0.11, run:
```
:lua vim.o.winborder = "rounded"
```

and for instance open telescope, which is a plenary-using plugin showing the issue.

fixes https://github.com/nvim-telescope/telescope.nvim/issues/3436

note that i do NOT have a clear vision of the whole plenary popups code, i just found the two windows that got a border with winborder that shouldn't, and enforced no border.