### PR TITLE
fix: type hints on Job:new

### DIFF
--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -1,10 +1,10 @@
 local vim = vim
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 local compat = require "plenary.compat"
 
 local F = require "plenary.functional"
 
----@class Job
+---@class JobOptions
 ---@field command string Command to run
 ---@field args? string[] List of arguments to pass
 ---@field cwd? string Working directory for job
@@ -20,6 +20,8 @@ local F = require "plenary.functional"
 ---@field on_exit? fun(self: Job, code: number, signal: number)
 ---@field maximum_results? number Stop processing results after this number
 ---@field writer? Job|table|string Job that writes to stdin of this job.
+
+---@class Job: JobOptions
 local Job = {}
 Job.__index = Job
 
@@ -78,7 +80,7 @@ end
 --- Map-like table
 
 ---Create a new job
----@param o Job
+---@param o JobOptions
 ---@return Job
 function Job:new(o)
   if not o then

--- a/lua/plenary/job.lua
+++ b/lua/plenary/job.lua
@@ -80,7 +80,7 @@ end
 --- Map-like table
 
 ---Create a new job
----@param o JobOptions
+---@param o JobOptions | string[]
 ---@return Job
 function Job:new(o)
   if not o then


### PR DESCRIPTION
When using `plenary.job` with LuaLS running, using `Job:new` resulted in an error saying that there were missing required fields: 
![image](https://github.com/user-attachments/assets/88c8704c-171f-49e9-aa16-dc21e084a78e)

These fields are the defined methods on `Job`. Since `Job:new` was annotated as accepting as param `o` a value of type `Job`, LuaLS is expecting `o` to have all of the fields of `Job`. This obviously isn't how `Job:new` is intended to be used.

This PR adds a separate type definition for a `JobOptions`, containing all of the field annotations originally on `Job`. It also makes the `Job` class definition inherit these fields. It then makes `Job:new` accept a `JobOptions` instead of `Job` for param `o`. This also adds `string[]` as an acceptable type for `o` to support that usage pattern.

There is one other unrelated change (happy to drop if it's not agreeable): setting `uv` to `vim.uv or vim.loop`, since `vim.loop` will be deprecated. This change also resolved several diagnostics raised by LuaLS/LazyDev in this module.

Thanks!