### PR TITLE
Add the ability to pass custom profiler options to `profile.start`

### DIFF
--- a/lua/plenary/profile.lua
+++ b/lua/plenary/profile.lua
@@ -9,10 +9,11 @@ local p = require'plenary.profile.p'
 ---@param opts table of options
 ---            flame (bool, default false) write log in flamegraph format
 --                   (see https://github.com/jonhoo/inferno)
+---            popts (string) custom profiler options
 function profile.start(out, opts)
     out = out or "profile.log"
     opts = opts or {}
-    local popts = "10,i1,s,m0"
+    local popts = opts.popts or "10,i1,s,m0"
     if opts.flame then popts = popts .. ",G" end
     p.start(popts, out)
 end


### PR DESCRIPTION
This fixes #662. Please see the PR also for more context.

It looks like `p.start` accepts some profiler options, but it wasn't possible to pass them through `profile.start` in plenary. It was hard coded, but it would be great if we can also pass our own custom profiler options. That way people who use the profiler can change the settings easily.

The main use case I had was to see the full paths of the Lua modules. I wanted to append `F` to the settings to make it work. With this option, I will be able to do it.

For example, here's an example output I had with "10,i1,s,m0,F,p,G" as options:  https://share.firefox.dev/460Xsdw

Thanks for the project!