### PR TITLE
Added lazy.nvim installation line

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Plug 'nvim-lua/plenary.nvim'
 
 Using [packer](https://github.com/wbthomason/packer.nvim):
 
-```
+```vim
 use "nvim-lua/plenary.nvim"
 ```
 
 Using [lazy](https://github.com/folke/lazy.nvim):
 
-```
+```vim
 return { "nvim-lua/plenary.nvim", lazy = true } --If using plugins directory structure
 
 --OR

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ use "nvim-lua/plenary.nvim"
 Using [lazy](https://github.com/folke/lazy.nvim):
 
 ```
-return { "nvim-lua/plenary.nvim", lazy = true }
+return { "nvim-lua/plenary.nvim", lazy = true } --If using plugins directory structure
+
+--OR
+
+{ "nvim-lua/plenary.nvim", lazy = true } --If using single file structure
 ```
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Plug 'nvim-lua/plenary.nvim'
 
 Using [packer](https://github.com/wbthomason/packer.nvim):
 
-```vim
+```lua
 use "nvim-lua/plenary.nvim"
 ```
 
 Using [lazy](https://github.com/folke/lazy.nvim):
 
-```vim
+```lua
 return { "nvim-lua/plenary.nvim", lazy = true } --If using plugins directory structure
 
 --OR

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Using [packer](https://github.com/wbthomason/packer.nvim):
 use "nvim-lua/plenary.nvim"
 ```
 
+Using [lazy](https://github.com/folke/lazy.nvim):
+
+```
+return { "nvim-lua/plenary.nvim", lazy = true }
+```
+
 ## Modules
 
 - [plenary.async](#plenaryasync)


### PR DESCRIPTION
I included the 2 ways of incorporation of a plugin using lazy.nvim:

1. In a single file setup
2. In the plugins directory as a separate file which will be automatically read by lazy

The "lazy = true" is suggested on the lazy.nvim documentation page, as plenary is a pure Lua plugin. Maybe this line can be removed because lazy behavior occurs by default without having to explicitly mention it.  