### PR TITLE
feat(filetypes): add zig and zon filetypes

### DIFF
--- a/data/plenary/filetypes/builtin.lua
+++ b/data/plenary/filetypes/builtin.lua
@@ -59,6 +59,8 @@ return {
     ['smithy'] = [[smithy]],
     ['sol'] = 'solidity',
     ['dtsi'] = 'dts',
+    ['zig'] = 'zig',
+    ['zon'] = 'zig',
   },
   file_name = {
     ['cakefile'] = 'coffee',


### PR DESCRIPTION
Adds filetypes for zig and zon (Zig Object Notation).

The zig filetype is needed to solve this [issue](https://github.com/lawrence-laz/neotest-zig/issues/40) in the neotest adapter for Zig.
Neotest uses plenary to detect the filetype. The adapter for zig was working so far due to [this monkeypatch](https://github.com/lawrence-laz/neotest-zig/blob/de63f3b9a182d374d2e71cf44385326682ec90e7/lua/neotest-zig/init.lua#L602) of `plenary.filetype`, which won't work anymore as of the latest commit in neotest.

The zon filetype is not really needed but might as well add it, it's also part of the [filetypes recognized by default](https://github.com/neovim/neovim/blob/35a7642647858f7b4ddc204ee869c399b678e7e8/runtime/lua/vim/filetype.lua#L1401) in nvim.