### PR TITLE
fix: deprecated vim.validate calls

### DIFF
--- a/lua/plenary/async/control.lua
+++ b/lua/plenary/async/control.lua
@@ -59,15 +59,14 @@ Semaphore.__index = Semaphore
 ---@param initial_permits number: the number of permits that it can give out
 ---@return Semaphore
 function Semaphore.new(initial_permits)
-  vim.validate {
-    initial_permits = {
-      initial_permits,
-      function(n)
-        return n > 0
-      end,
-      "number greater than 0",
-    },
-  }
+  vim.validate(
+    "initial_permits",
+    initial_permits,
+    function(n)
+      return n > 0
+    end,
+    "number greater than 0"
+  )
 
   return setmetatable({ permits = initial_permits, handles = {} }, Semaphore)
 end

--- a/lua/plenary/async_lib/util.lua
+++ b/lua/plenary/async_lib/util.lua
@@ -112,15 +112,14 @@ Semaphore.__index = Semaphore
 ---@param initial_permits number: the number of permits that it can give out
 ---@return Semaphore
 function Semaphore.new(initial_permits)
-  vim.validate {
-    initial_permits = {
-      initial_permits,
-      function(n)
-        return n > 0
-      end,
-      "number greater than 0",
-    },
-  }
+  vim.validate(
+    "initial_permits",
+    initial_permits,
+    function(n)
+      return n > 0
+    end,
+    "number greater than 0"
+  )
 
   return setmetatable({ permits = initial_permits, handles = {} }, Semaphore)
 end

--- a/lua/plenary/benchmark/init.lua
+++ b/lua/plenary/benchmark/init.lua
@@ -93,10 +93,8 @@ end
 ---@param name string @benchmark name
 ---@param opts benchmark_run_opts
 local bench = function(name, opts)
-  vim.validate {
-    opts = { opts, "table" },
-    fun = { opts.fun, "table" },
-  }
+  vim.validate("opts", opts, "table")
+  vim.validate("fun", opts.fun, "table")
   opts.warmup = vim.F.if_nil(opts.warmup, 3)
   opts.runs = vim.F.if_nil(opts.runs, 5)
 


### PR DESCRIPTION
Hello! My `:checkhealth` today gave some warnings about this plugin's use of the [deprecated use](https://neovim.io/doc/user/deprecated/) of `vim.validate(table)`.

I've gone through and moved those uses to the new usage, which is mostly just unpacking the tables being used.

Let me know if you need any changes.